### PR TITLE
Revert "updates tenant label to genesis"

### DIFF
--- a/stakater/mattermost-instance/Chart.yaml
+++ b/stakater/mattermost-instance/Chart.yaml
@@ -24,10 +24,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.21
+version: 0.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.17.0"
+appVersion: "1.16.0"

--- a/stakater/mattermost-instance/values.yaml
+++ b/stakater/mattermost-instance/values.yaml
@@ -5,7 +5,7 @@
 namespace:
   createNamespace: false
   labels:
-    stakater.com/tenant: genesis
+    stakater.com/tenant: gabbar
 
 tenant:
   enabled: true


### PR DESCRIPTION
reverting back, cause it needed "rebase and merge" and not just merge. Pipelines fail with just using merge