### PR TITLE
[skip-ci] Replace code owner with group

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,6 +8,7 @@ on:
     - 'README.md'
     - 'stakater/(.*)/README.md'
     - '.github/workflows'
+    - 'CODEOWNERS'
 
 jobs:
   build:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,14 +12,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     name: Build
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"    
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
 
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    if: "! contains(toJSON(github.event.pull_request.title), '[skip-ci]')"
 
     steps:
 
@@ -22,10 +22,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-
-    - name: TEMP
-      run: |
-        echo "${{toJSON(github.event.commits.*.message)}}"
 
     - id: get-chart
       name: 'Get modified charts'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,16 +18,9 @@ jobs:
 
     steps:
 
-    - name: messages
-      run: |
-        echo '${{toJSON(github.event.commits.*.message)}}'
-        echo '${{toJSON(github.event.commits)}}'
-
     - name: Check out code
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
         fetch-depth: 0
 
     - id: get-chart

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
     paths-ignore:
-    - 'README.md'
-    - 'stakater/(.*)/README.md'
-    - '.github/workflows'
-    - 'CODEOWNERS'
+      - 'README.md'
+      - 'stakater/(.*)/README.md'
+      - '.github/workflows'
+      - 'CODEOWNERS'
 
 jobs:
   build:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: TEMP
       run: |
-        echo "${{github.event.commits.*.message}}"
+        echo "${{toJSON(github.event.commits.*.message)}}"
 
     - id: get-chart
       name: 'Get modified charts'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -23,6 +23,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: TEMP
+      run: |
+        echo "${{github.event.commits}}"
+
     - id: get-chart
       name: 'Get modified charts'
       run: |

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,6 +18,11 @@ jobs:
 
     steps:
 
+    - name: messages
+      run: |
+        echo '${{toJSON(github.event.commits.*.message)}}'
+        echo '${{toJSON(github.event.commits)}}'
+
     - name: Check out code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: TEMP
       run: |
-        echo "${{github.event.commits}}"
+        echo "${{github.event.commits.*.message}}"
 
     - id: get-chart
       name: 'Get modified charts'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,7 +1,7 @@
 name: Pull Request
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths-ignore:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,8 +1,8 @@
 name: Push
 
 concurrency: 
- group: push_on_master
- cancel-in-progress: false
+  group: push_on_master
+  cancel-in-progress: false
 
 on:
   push:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,6 +11,7 @@ on:
     paths-ignore:
     - 'README.md'
     - 'stakater/(.*)/README.md'
+    - 'CODEOWNERS'
 
 jobs:
   build:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     name: Build
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    if: "! contains(toJSON(github.event.pull_request.title), '[skip-ci]')"
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -9,9 +9,9 @@ on:
     branches:
       - main
     paths-ignore:
-    - 'README.md'
-    - 'stakater/(.*)/README.md'
-    - 'CODEOWNERS'
+      - 'README.md'
+      - 'stakater/(.*)/README.md'
+      - 'CODEOWNERS'
 
 jobs:
   build:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,1 @@
-* @faizanahmad055
-* @rasheedamir
-* @hazim1093
-* @usamaahmadkhan
-* @hanzala1234
+*   @stakater/stakater-admin


### PR DESCRIPTION
Use group instead of hardcoding users as code owners

CI has to be skipped because `paths-ignore` does not include `CODEOWNERS` and seem to always trigger until it has been added on main