### PR TITLE
set empty labels as default to allow inherited charts to define their own labels

### DIFF
--- a/postgres-observability/values.yaml
+++ b/postgres-observability/values.yaml
@@ -31,9 +31,7 @@ prometheus:
           scrapeTimeout: 5s
           path: /metrics
       selector:
-        matchLabels:
-          postgres-operator.crunchydata.com/crunchy-postgres-exporter: 'true'
-          postgres-operator.crunchydata.com/cluster: postgres
+        matchLabels: {}
       namespaceSelector:
           any: true
 


### PR DESCRIPTION
set empty labels as default to allow inherited charts to define their own labels