### PR TITLE
fix: conditionally include targetNamespaces in OperatorGroup

### DIFF
--- a/operators-installer/templates/operatorgroup.yaml
+++ b/operators-installer/templates/operatorgroup.yaml
@@ -9,11 +9,16 @@ metadata:
   labels:
     {{- include "operators-installer.labels" $ | nindent 4 }}
 spec:
+  {{- if or .targetOwnNamespace (gt (len .otherTargetNamespaces) 0) }}
   targetNamespaces:
   {{- if .targetOwnNamespace }}
   - {{ .name |  default $.Release.Namespace }}
   {{- end }}
   {{- range $otherTargetNamespace := .otherTargetNamespaces }}
   - {{ $otherTargetNamespace }}
+  {{- end }}
+  {{- end }}
+  {{- if .upgradeStrategy }}
+  upgradeStrategy: {{ .upgradeStrategy }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Only include targetNamespaces field when targetOwnNamespace is true or otherTargetNamespaces array is not empty. This prevents invalid OperatorGroup specs with empty targetNamespaces.