### PR TITLE
fix(crossplane-observability): reconcile upjet rule labels + deflake weekly drift check

### DIFF
--- a/.github/workflows/crossplane-observability-validate.yaml
+++ b/.github/workflows/crossplane-observability-validate.yaml
@@ -65,14 +65,19 @@ jobs:
       - name: Capture from the pinned stack
         working-directory: crossplane-observability
         run: ./tests/integration.sh
-      - name: Fail if fixtures or captured allowlist drifted
+      - name: Fail if the captured metric name set drifted
         working-directory: crossplane-observability
         run: |
-          if ! git diff --quiet -- tests/fixtures tests/metrics-allowlist.captured.txt; then
-            echo "::error::Captured metrics differ from what is committed. The pinned stack"
-            echo "::error::emits a different metric set than tests/fixtures records. Review:"
-            git diff --stat -- tests/fixtures tests/metrics-allowlist.captured.txt
+          # Diff only the DERIVED allowlist (deterministic: sorted, de-duplicated metric
+          # names, no timestamps). The raw tests/fixtures/*.txt dumps are intentionally NOT
+          # byte-diffed — they carry live counter/gauge values and non-deterministic series
+          # ordering, so they churn on every scrape even when the metric SET is unchanged.
+          # A renamed/added/removed metric shows up here; that is the signal this job exists for.
+          if ! git diff --quiet -- tests/metrics-allowlist.captured.txt; then
+            echo "::error::The pinned stack emits a different metric name set than"
+            echo "::error::tests/metrics-allowlist.captured.txt records. Review and, if intended,"
+            echo "::error::commit the regenerated allowlist (and refreshed tests/fixtures/*)."
             git diff -- tests/metrics-allowlist.captured.txt
             exit 1
           fi
-          echo "fixtures and captured allowlist match the live pinned capture."
+          echo "captured metric name set matches the live pinned capture."

--- a/crossplane-observability/Chart.yaml
+++ b/crossplane-observability/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crossplane-observability
 description: A Helm chart for Crossplane observability (ServiceMonitor + PrometheusRule + Grafana dashboard), integrated with OpenShift user-workload monitoring.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.0.1"

--- a/crossplane-observability/templates/prometheus/rules/cloud/cloud-api-throttling.yaml
+++ b/crossplane-observability/templates/prometheus/rules/cloud/cloud-api-throttling.yaml
@@ -23,8 +23,11 @@ spec:
           # typically cloud-side rate limiting. Threshold is configurable (seconds); the
           # roadmap notes it should be calibrated against the providers' configured poll
           # interval rather than a fixed number.
+          # upjet_resource_reconcile_delay_seconds_bucket is labelled group/kind/version
+          # (confirmed on a live build) — group by (group, kind) so the same Kind name in
+          # two different API groups isn't merged into one p95.
           expr: |
-            histogram_quantile(0.95, sum by (le, kind) (
+            histogram_quantile(0.95, sum by (le, group, kind) (
               rate(upjet_resource_reconcile_delay_seconds_bucket{job="{{ .Values.crossplane.providers.job }}"}[15m])
             )) > {{ $r.thresholdSeconds }}
           for: {{ $r.for }}
@@ -32,6 +35,6 @@ spec:
             severity: {{ $r.severity }}
             rulesgroup: crossplane
           annotations:
-            summary: "Cloud-API throttling suspected for {{`{{ $labels.kind }}`}}"
-            description: "p95 reconcile delay for {{`{{ $labels.kind }}`}} is {{`{{ $value | humanizeDuration }}`}}, above the {{ $r.thresholdSeconds }}s threshold, for more than {{ $r.for }} — the provider is falling behind, typically due to cloud-provider rate limiting (upstream of Crossplane)."
+            summary: "Cloud-API throttling suspected for {{`{{ $labels.kind }} ({{ $labels.group }})`}}"
+            description: "p95 reconcile delay for {{`{{ $labels.kind }} ({{ $labels.group }})`}} is {{`{{ $value | humanizeDuration }}`}}, above the {{ $r.thresholdSeconds }}s threshold, for more than {{ $r.for }} — the provider is falling behind, typically due to cloud-provider rate limiting (upstream of Crossplane)."
 {{- end }}

--- a/crossplane-observability/templates/prometheus/rules/resource-health/ttr-degraded.yaml
+++ b/crossplane-observability/templates/prometheus/rules/resource-health/ttr-degraded.yaml
@@ -20,8 +20,12 @@ spec:
     - name: crossplane.resource-health
       rules:
         - alert: TTRDegraded
+          # The two source metrics carry different identity labels (confirmed on a live
+          # build): the native metric is per-`gvk`; upjet_resource_ttr_bucket is labelled
+          # `group`/`kind`/`version` and has NO `gvk` — so the group-by and the annotation
+          # switch with upjet.enabled, else the upjet series all collapse to one empty group.
           expr: |
-            histogram_quantile({{ $r.quantile }}, sum by (le, gvk) (
+            histogram_quantile({{ $r.quantile }}, sum by (le, {{ if .Values.upjet.enabled }}group, kind{{ else }}gvk{{ end }}) (
               rate(
               {{- if .Values.upjet.enabled }}
                 upjet_resource_ttr_bucket{job="{{ .Values.crossplane.providers.job }}"}[30m]
@@ -35,6 +39,6 @@ spec:
             severity: {{ $r.severity }}
             rulesgroup: crossplane
           annotations:
-            summary: "Slow provisioning for {{`{{ $labels.gvk }}`}} (p{{ $r.quantile | mulf 100 | int }} TTR over SLO)"
-            description: "p{{ $r.quantile | mulf 100 | int }} time-to-readiness for {{`{{ $labels.gvk }}`}} is {{`{{ $value | humanizeDuration }}`}}, above the {{ $r.thresholdSeconds }}s SLO, for more than {{ $r.for }}."
+            summary: "Slow provisioning for {{ if .Values.upjet.enabled }}{{`{{ $labels.kind }} ({{ $labels.group }})`}}{{ else }}{{`{{ $labels.gvk }}`}}{{ end }} (p{{ $r.quantile | mulf 100 | int }} TTR over SLO)"
+            description: "p{{ $r.quantile | mulf 100 | int }} time-to-readiness for {{ if .Values.upjet.enabled }}{{`{{ $labels.kind }} ({{ $labels.group }})`}}{{ else }}{{`{{ $labels.gvk }}`}}{{ end }} is {{`{{ $value | humanizeDuration }}`}}, above the {{ $r.thresholdSeconds }}s SLO, for more than {{ $r.for }}."
 {{- end }}

--- a/crossplane-observability/tests/capture-metrics.sh
+++ b/crossplane-observability/tests/capture-metrics.sh
@@ -78,14 +78,17 @@ fi
 extract() { grep -hvE '^#' "$@" 2>/dev/null | sed -E 's/[ {].*$//' | grep -E '^[a-zA-Z_:][a-zA-Z0-9_:]*$' || true; }
 
 {
-  echo "# metrics-allowlist.txt — CAPTURED from live Crossplane metrics on $(date -u +%FT%TZ)"
+  echo "# metrics-allowlist.txt — CAPTURED metric names from a real Crossplane build (see tests/fixtures/CAPTURE.md for the pinned versions)."
   echo "# Source endpoints: core=${CORE_SVC:-n/a} provider-selector=${PROVIDER_SELECTOR:-n/a} ns=${NS}"
   echo "# Regenerate with tests/capture-metrics.sh. check_metrics.py validates rules against this."
   echo "#"
   echo "# NOTE: this is the FULL emitted metric set. The chart only references a subset; that"
   echo "#       is fine — the gate only requires referenced metrics to be present here."
   echo
-  extract "${tmp}"/*.txt | sort -u
+  # LC_ALL=C so the ordering is byte-collation, identical on every machine/CI runner —
+  # otherwise a runner's default locale reorders punctuation (e.g. `_`) and the weekly
+  # drift check sees phantom churn even when the metric name set is unchanged.
+  extract "${tmp}"/*.txt | LC_ALL=C sort -u
 } > "$OUT"
 
 echo ">> wrote $(grep -cvE '^#|^$' "$OUT") metric names to $OUT" >&2

--- a/crossplane-observability/tests/metrics-allowlist.captured.txt
+++ b/crossplane-observability/tests/metrics-allowlist.captured.txt
@@ -1,4 +1,4 @@
-# metrics-allowlist.txt — CAPTURED from live Crossplane metrics on 2026-06-14T18:50:48Z
+# metrics-allowlist.txt — CAPTURED metric names from a real Crossplane build (see tests/fixtures/CAPTURE.md for the pinned versions).
 # Source endpoints: core=crossplane provider-selector=pkg.crossplane.io/provider ns=crossplane-system
 # Regenerate with tests/capture-metrics.sh. check_metrics.py validates rules against this.
 #

--- a/crossplane-observability/tests/unit/rules.test.yaml
+++ b/crossplane-observability/tests/unit/rules.test.yaml
@@ -155,3 +155,97 @@ tests:
             exp_annotations:
               summary: "Composite XProject/e2e not synced"
               description: "Composite XProject/e2e has Synced != True for more than 15m — Crossplane cannot reconcile its desired state (often a reconcile error)."
+
+  # --- Story 1.2 (upjet branch): TTRDegraded groups by (group, kind) ---
+  # Regression for the label bug: upjet_resource_ttr_bucket has group/kind/version and NO
+  # `gvk`; the rendered rule (upjet.enabled=true in validate.sh) must group by (group, kind)
+  # so per-type series survive and the annotation is populated. p95 lands in (300s,600s] -> 585s.
+  - name: TTR degraded on upjet providers (group/kind labels)
+    interval: 1m
+    input_series:
+      - series: 'upjet_resource_ttr_bucket{job="crossplane-providers", group="s3.aws.m.upbound.io", kind="Bucket", version="v1beta1", le="300"}'
+        values: '0+0x60'
+      - series: 'upjet_resource_ttr_bucket{job="crossplane-providers", group="s3.aws.m.upbound.io", kind="Bucket", version="v1beta1", le="600"}'
+        values: '0+10x60'
+      - series: 'upjet_resource_ttr_bucket{job="crossplane-providers", group="s3.aws.m.upbound.io", kind="Bucket", version="v1beta1", le="+Inf"}'
+        values: '0+10x60'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: TTRDegraded
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              rulesgroup: crossplane
+              group: s3.aws.m.upbound.io
+              kind: Bucket
+            exp_annotations:
+              summary: "Slow provisioning for Bucket (s3.aws.m.upbound.io) (p95 TTR over SLO)"
+              description: "p95 time-to-readiness for Bucket (s3.aws.m.upbound.io) is 9m 45s, above the 300s SLO, for more than 30m."
+
+  # --- Story 6.1: CloudAPIThrottling groups by (group, kind) on the upjet delay histogram ---
+  # p95 reconcile delay lands in (60s,120s] -> 117s, above the 60s threshold.
+  - name: cloud API throttling on upjet delay histogram
+    interval: 1m
+    input_series:
+      - series: 'upjet_resource_reconcile_delay_seconds_bucket{job="crossplane-providers", group="route53.aws.m.upbound.io", kind="Record", version="v1beta1", le="60"}'
+        values: '0+0x30'
+      - series: 'upjet_resource_reconcile_delay_seconds_bucket{job="crossplane-providers", group="route53.aws.m.upbound.io", kind="Record", version="v1beta1", le="120"}'
+        values: '0+10x30'
+      - series: 'upjet_resource_reconcile_delay_seconds_bucket{job="crossplane-providers", group="route53.aws.m.upbound.io", kind="Record", version="v1beta1", le="+Inf"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: CloudAPIThrottling
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              rulesgroup: crossplane
+              group: route53.aws.m.upbound.io
+              kind: Record
+            exp_annotations:
+              summary: "Cloud-API throttling suspected for Record (route53.aws.m.upbound.io)"
+              description: "p95 reconcile delay for Record (route53.aws.m.upbound.io) is 1m 57s, above the 60s threshold, for more than 15m — the provider is falling behind, typically due to cloud-provider rate limiting (upstream of Crossplane)."
+
+  # --- Story 5.1: FunctionErrorRate splits on result_severity="Fatal" ---
+  # The response-total metric is labelled result_severity (Normal/Fatal), NOT result="error".
+  # 1 Fatal/min against 101 total/min -> ratio ~0.99% > the 0.5% SLO.
+  - name: function error rate uses result_severity=Fatal
+    interval: 1m
+    input_series:
+      - series: 'function_run_function_response_total{job="crossplane", function_name="function-kcl", result_severity="Normal"}'
+        values: '0+100x60'
+      - series: 'function_run_function_response_total{job="crossplane", function_name="function-kcl", result_severity="Fatal"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: FunctionErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              rulesgroup: crossplane
+              function_name: function-kcl
+            exp_annotations:
+              summary: "Composition function function-kcl error rate high"
+              description: "Function function-kcl error ratio is 0.9901% (SLO < 0.005) for more than 15m."
+
+  # --- Story 4.2: CircuitBreakerDropRatioHigh splits on result="Dropped" ---
+  # events_total is labelled controller + result (Allowed/Dropped/HalfOpenAllowed).
+  # 30 Dropped/min against 100 total/min -> 30% > the 20% threshold.
+  - name: circuit breaker drop ratio uses result=Dropped
+    interval: 1m
+    input_series:
+      - series: 'circuit_breaker_events_total{job="crossplane", controller="composite/databases.data.cloud.stakater.com", result="Allowed"}'
+        values: '0+70x60'
+      - series: 'circuit_breaker_events_total{job="crossplane", controller="composite/databases.data.cloud.stakater.com", result="Dropped"}'
+        values: '0+30x60'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: CircuitBreakerDropRatioHigh
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              rulesgroup: crossplane
+              controller: composite/databases.data.cloud.stakater.com
+            exp_annotations:
+              summary: "Circuit breaker dropping events for composite/databases.data.cloud.stakater.com"
+              description: "Controller composite/databases.data.cloud.stakater.com is dropping 30% of watch events (> 0.2) for more than 5m — a thrashing XR may be starving other tenants."


### PR DESCRIPTION
Follow-up to #274 (now merged). Two independent, low-risk fixes to the `crossplane-observability` chart. Static validation (`tests/validate.sh`) is green.

## 1. Reconcile the upjet rules to real metric labels
`upjet_resource_ttr_bucket` and `upjet_resource_reconcile_delay_seconds_bucket` are labelled `group`/`kind`/`version` on a live build — they carry **no `gvk`** label (verified against a live cluster during #274 deploy validation).

- **`ttr-degraded.yaml`** — when `upjet.enabled`, group by `(group, kind)` and switch the annotation to `{{ $labels.kind }} ({{ $labels.group }})`; otherwise keep `gvk`. Previously every upjet series collapsed into one group with a blank annotation.
- **`cloud-api-throttling.yaml`** — group by `(group, kind)` instead of `kind` only, so the same Kind name in two API groups isn't merged into one p95.
- **`unit/rules.test.yaml`** — new promtool cases for both upjet branches, plus `FunctionErrorRate` (`result_severity="Fatal"`) and `CircuitBreakerDropRatioHigh` (`result="Dropped"`) to lock the label contracts.

## 2. De-flake the weekly metric-drift check
The scheduled `integration-capture` job (runs weekly / on dispatch, **not** on PRs) has been failing every run on noise, not a real metric change:
- a `$(date)` timestamp baked into the allowlist header, and
- live counter/gauge values + locale-dependent sort ordering in the raw `/metrics` scrapes.

Fix: the allowlist header no longer carries a timestamp (provenance lives in the pinned-versions table in `CAPTURE.md`), `capture-metrics.sh` pins `LC_ALL=C sort` for byte-stable ordering on any runner, and the drift check now diffs only the deterministic, `sort -u`'d allowlist (metric **names**) rather than the noisy raw fixtures. The allowlist is now byte-reproducible from the committed fixtures. A genuine change in the emitted metric set still fails the job — which is the signal it exists for.

`Chart.yaml`: 0.1.1 → 0.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)