### PR TITLE
fix(operators-installer): make manual InstallPlan approval robust to catalog channel drift

### DIFF
--- a/operators-installer/templates/installplan-approver/csv-verifier.yaml
+++ b/operators-installer/templates/installplan-approver/csv-verifier.yaml
@@ -25,70 +25,65 @@ spec:
           - /bin/bash
           - -c
           - |
-            counter=0
-            SLEEPER_TMP=0
-            get_status=`oc get clusterserviceversion -n ${Namespace} ${SUBSCRIPTION_CSV} -o jsonpath={.status.phase}`
-            until [ "$get_status" != "" ]; do
-              # do not wait forever
-              let "counter=counter+1"
-              echo "Attempt $counter of $max_timer"
+            export HOME=/tmp/approver
+            echo
 
-              if [[ $counter -eq $max_timer ]]
-              then
-                echo "Giving up. Operator installation failed"
+            # ----------------------------------------------------------------
+            # Decide WHICH csv to verify.
+            #   strict : the pinned csv must be the one that reaches Succeeded.
+            #   track  : verify whatever the Subscription actually resolved to
+            #            (status.installedCSV), since that may be the channel
+            #            head rather than the pin.
+            # ----------------------------------------------------------------
+            verifyCSV="${SUBSCRIPTION_CSV}"
+            if [ "${PIN_POLICY}" = "track" ]; then
+              verifyCSV=""
+              counter=0
+              while [ -z "${verifyCSV}" ]; do
+                verifyCSV=$(oc get subscriptions.operators.coreos.com -n ${Namespace} ${SUBSCRIPTION} -o=jsonpath="{.status.installedCSV}")
+                if [ -n "${verifyCSV}" ]; then break; fi
+                counter=$((counter+1))
+                if [ "${counter}" -ge "${MAX_ATTEMPTS}" ]; then
+                  echo "Giving up: Subscription ${SUBSCRIPTION} never reported an installedCSV. Operator installation failed."
+                  exit 3
+                fi
+                echo "Waiting for Subscription ${SUBSCRIPTION} to resolve installedCSV... (${counter}/${MAX_ATTEMPTS})"
+                sleep "${SLEEP_TIMER}"
+              done
+            fi
+            echo "Verifying ClusterServiceVersion ${verifyCSV} in namespace ${Namespace}"
+
+            # Wait for the CSV to reach Succeeded (bounded).
+            counter=0
+            get_status=""
+            until [ "${get_status}" = "Succeeded" ]; do
+              get_status=$(oc get clusterserviceversion -n ${Namespace} ${verifyCSV} -o jsonpath="{.status.phase}" 2>/dev/null)
+              if [ "${get_status}" = "Succeeded" ]; then break; fi
+              counter=$((counter+1))
+              if [ "${counter}" -ge "${MAX_ATTEMPTS}" ]; then
+                echo "Giving up. CSV ${verifyCSV} did not reach Succeeded (last phase: '${get_status}'). Operator installation failed."
                 exit 3
               fi
-
-              echo "Operator not yet ready ... Waiting $sleep_timer seconds"
-              while [[ $SLEEPER_TMP -le "$sleep_timer" ]]; do
-                echo -n "."
-                sleep 1
-                SLEEPER_TMP=$(($SLEEPER_TMP+1))
-              done
-              get_status=`oc get clusterserviceversion -n ${Namespace} ${SUBSCRIPTION_CSV} -o jsonpath={.status.phase}`
+              echo "CSV ${verifyCSV} phase: '${get_status}' (attempt ${counter}/${MAX_ATTEMPTS})"
+              sleep "${SLEEP_TIMER}"
             done
 
-            echo "Checking status of ${SUBSCRIPTION_CSV}. Current status: $get_status"
-            # Wait until operator is ready
-            counter=0
-            SLEEPER_TMP=0
-            until [ "$get_status" == "Succeeded" ]; do
-            let "counter=counter+1"
-              echo "Attempt $counter of $max_timer"
-               if [[ $counter -eq $max_timer ]]
-              then
-                echo "Giving up. Operator installation failed"
-                exit 3
-              fi
-              echo "Operator deployment is ongoing. Current status: $get_status"
-              #sleep $sleep_timer
-              while [[ $SLEEPER_TMP -le "$sleep_timer" ]]; do
-                echo -n "."
-                sleep 1
-                SLEEPER_TMP=$(($SLEEPER_TMP+1))
-              done
-              if [ "$get_status" == "Succeeded" ];
-              then
-                status=$?
-              fi
-              get_status=`oc get clusterserviceversion -n ${Namespace} ${SUBSCRIPTION_CSV} -o jsonpath={.status.phase}`
-            done
-            oc get clusterserviceversion -n ${Namespace} ${SUBSCRIPTION_CSV}
-            echo "Falling to sleep"
-
-            SLEEPER_TMP=0
-
-            while [[ $SLEEPER_TMP -le "10" ]]; do
-                echo -n "."
-                sleep 1
-                SLEEPER_TMP=$(($SLEEPER_TMP+1))
-            done
+            echo "CSV ${verifyCSV} reached Succeeded."
+            oc get clusterserviceversion -n ${Namespace} ${verifyCSV}
         imagePullPolicy: Always
         env:
         - name: SUBSCRIPTION_CSV
-          value: {{ .csv }}
+          value: {{ .csv | quote }}
+        - name: SUBSCRIPTION
+          value: {{ .name | quote }}
         - name: Namespace
-          value: {{ .namespace | default $.Release.Namespace }}
+          value: {{ .namespace | default $.Release.Namespace | quote }}
+        - name: PIN_POLICY
+          value: {{ .pinPolicy | default "strict" | quote }}
+        - name: MAX_ATTEMPTS
+          value: {{ .installPlanVerifierAttempts | default 60 | quote }}
+        - name: SLEEP_TIMER
+          value: {{ .installPlanVerifierSleepSeconds | default 5 | quote }}
       dnsPolicy: ClusterFirst
       restartPolicy: Never
       serviceAccount: {{ include "operators-installer.approverName" . }}

--- a/operators-installer/templates/installplan-approver/csv-verifier.yaml
+++ b/operators-installer/templates/installplan-approver/csv-verifier.yaml
@@ -31,23 +31,24 @@ spec:
             # ----------------------------------------------------------------
             # Decide WHICH csv to verify.
             #   strict : the pinned csv must be the one that reaches Succeeded.
-            #   track  : verify whatever the Subscription actually resolved to
-            #            (status.installedCSV), since that may be the channel
-            #            head rather than the pin.
+            #   track  : verify the csv OLM resolved to (status.currentCSV) - the
+            #            version being installed now, which may be the channel head
+            #            rather than the pin. (Not installedCSV: that is the OLD
+            #            version until the upgrade completes and would pass early.)
             # ----------------------------------------------------------------
             verifyCSV="${SUBSCRIPTION_CSV}"
             if [ "${PIN_POLICY}" = "track" ]; then
               verifyCSV=""
               counter=0
               while [ -z "${verifyCSV}" ]; do
-                verifyCSV=$(oc get subscriptions.operators.coreos.com -n ${Namespace} ${SUBSCRIPTION} -o=jsonpath="{.status.installedCSV}")
+                verifyCSV=$(oc get subscriptions.operators.coreos.com -n ${Namespace} ${SUBSCRIPTION} -o=jsonpath="{.status.currentCSV}")
                 if [ -n "${verifyCSV}" ]; then break; fi
                 counter=$((counter+1))
                 if [ "${counter}" -ge "${MAX_ATTEMPTS}" ]; then
-                  echo "Giving up: Subscription ${SUBSCRIPTION} never reported an installedCSV. Operator installation failed."
+                  echo "Giving up: Subscription ${SUBSCRIPTION} never reported a currentCSV. Operator installation failed."
                   exit 3
                 fi
-                echo "Waiting for Subscription ${SUBSCRIPTION} to resolve installedCSV... (${counter}/${MAX_ATTEMPTS})"
+                echo "Waiting for Subscription ${SUBSCRIPTION} to resolve currentCSV... (${counter}/${MAX_ATTEMPTS})"
                 sleep "${SLEEP_TIMER}"
               done
             fi

--- a/operators-installer/templates/installplan-approver/installplan-approver.yaml
+++ b/operators-installer/templates/installplan-approver/installplan-approver.yaml
@@ -27,85 +27,126 @@ spec:
           - |
             export HOME=/tmp/approver
             echo
+
+            # ----------------------------------------------------------------
+            # Resolve the Subscription UID (bounded retry).
+            # ----------------------------------------------------------------
             subscriptionUID=""
+            attempt=0
             while [ -z "${subscriptionUID}" ]; do
               echo "Get Subscription (${SUBSCRIPTION}) UID"
-              subscriptionUID=$(oc get subscriptions.operators.coreos.com --field-selector metadata.name=${SUBSCRIPTION} -o=jsonpath="{.items[0].metadata.uid}")
+              subscriptionUID=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} --field-selector metadata.name=${SUBSCRIPTION} -o=jsonpath="{.items[0].metadata.uid}")
               if [ -z "${subscriptionUID}" ]; then
-                echo "Subscription UID not found, retrying in 5 seconds..."
+                attempt=$((attempt+1))
+                if [ "${attempt}" -ge "${LOOKUP_ATTEMPTS}" ]; then
+                  echo "ERROR: Subscription ${SUBSCRIPTION} not found after ${LOOKUP_ATTEMPTS} attempts."
+                  exit 1
+                fi
+                echo "Subscription UID not found, retrying in 5 seconds... (${attempt}/${LOOKUP_ATTEMPTS})"
                 sleep 5
               fi
             done
             echo "Subscription (${SUBSCRIPTION}) UID: ${subscriptionUID}"
-            if [ ! -z "subscriptionUID" ]; then
-              # this complicated go-template finds an InstallPlan where both the .spec.clusterServiceVersionNames contains the expected CSV
-              # and .metadata.ownerReferences contains the expected Subscription owner. JsonPath doesn't let you do and statements and go-templates
-              # done seem to have a function for checking if a value is in an array without iterating. so here we are.
-              # NOTE 1: if for whatever reason multiple InstallPlans are found that are associated with the Subscription for the correct CSV, only the first will be approved
-              # NOTE 2: this is nested in {{` `}} so that helm doesn't try to interpret the go template
-              {{`installPlanGoTemplate=$(cat << EOF
-              {{- \$installPlanName := "" -}}
-              {{- range .items -}}
-                {{- \$installPlanItem := . -}}
-                {{- range .spec.clusterServiceVersionNames -}}
-                  {{- if and (eq . "${SUBSCRIPTION_CSV}") (not \$installPlanName) -}}
-                    {{- if or (eq \$installPlanItem.status.phase "RequiresApproval") (eq \$installPlanItem.status.phase "Complete") -}}
-                      {{- range \$installPlanItem.metadata.ownerReferences -}}
-                        {{- if eq .uid "${subscriptionUID}" -}}
-                          {{- \$installPlanName = \$installPlanItem.metadata.name -}}
-                        {{- end -}}
-                      {{- end -}}
-                    {{- end -}}
-                  {{- end -}}
-                {{- end -}}
-              {{- end -}}
-              {{ \$installPlanName }}
-            EOF
-              )`}}
 
-              echo
-              echo "Get InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner"
-              installPlan=""
-              while [ -z "${installPlan}" ]; do
-                echo "Get InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner"
-                installPlan=$(oc get installplan -o=go-template="${installPlanGoTemplate}")
-                if [ -z "${installPlan}" ]; then
-                  echo "InstallPlan not found, retrying in 5 seconds..."
-                  sleep 5
+            # ----------------------------------------------------------------
+            # go-template: emit one "name|csv|phase|approved" line per InstallPlan
+            # owned by this Subscription (ANY csv). Unlike the previous version
+            # this does NOT filter on the pinned csv, so the selection logic below
+            # is robust to the catalog channel head having moved past the pin.
+            # NOTE: nested in {{`  `}} so helm does not interpret the go template;
+            #       go-template vars are written \$var, shell vars stay ${var}.
+            # ----------------------------------------------------------------
+            {{`ownedInstallPlansGoTemplate=$(cat << EOF
+            {{- range .items -}}{{- \$ip := . -}}{{- range \$ip.metadata.ownerReferences -}}{{- if eq .uid "${subscriptionUID}" -}}{{ \$ip.metadata.name }}|{{ index \$ip.spec.clusterServiceVersionNames 0 }}|{{ \$ip.status.phase }}|{{ \$ip.spec.approved }}
+            {{ end -}}{{- end -}}{{- end -}}
+            EOF
+            )`}}
+
+            echo
+            echo "Reconciling InstallPlans for Subscription ${SUBSCRIPTION} (pinned csv=${SUBSCRIPTION_CSV}, pinPolicy=${PIN_POLICY})"
+            attempt=0
+            while true; do
+              # strip go-template indentation whitespace (fields never contain spaces)
+              owned=$(oc get installplan -n ${SUBSCRIPTION_NAMESPACE} -o=go-template="${ownedInstallPlansGoTemplate}" | tr -d ' ')
+              installedCSV=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} ${SUBSCRIPTION} -o=jsonpath="{.status.installedCSV}")
+
+              # a pending InstallPlan for the PINNED csv (initial install of the pin)
+              pinnedPending=$(echo "${owned}" | grep -F "|${SUBSCRIPTION_CSV}|RequiresApproval|" | head -n1)
+              # any pending InstallPlan owned by this Subscription (channel head / upgrade)
+              anyPending=$(echo "${owned}" | grep -F "|RequiresApproval|" | head -n1)
+
+              # 1. The pinned version is offered and pending -> approve it.
+              if [ -n "${pinnedPending}" ]; then
+                toApprove=$(echo "${pinnedPending}" | cut -d'|' -f1)
+                echo "Approving InstallPlan ${toApprove} for pinned csv ${SUBSCRIPTION_CSV}"
+                oc patch installplan -n ${SUBSCRIPTION_NAMESPACE} ${toApprove} --type=json -p='[{"op":"replace","path":"/spec/approved","value":true}]'
+                exit 0
+              fi
+
+              # 2. The pin is already installed -> nothing to do. Any other pending
+              #    InstallPlan is an un-approved upgrade we intentionally leave
+              #    pending: that is the whole point of a Manual pin. Idempotent on
+              #    every Argo re-sync.
+              if [ "${installedCSV}" = "${SUBSCRIPTION_CSV}" ]; then
+                echo "Pinned csv ${SUBSCRIPTION_CSV} already installed. Nothing to approve."
+                if [ -n "${anyPending}" ]; then
+                  echo "NOTE: a newer InstallPlan is pending but is intentionally left unapproved (Manual pin)."
                 fi
-              done
-              echo "InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner: ${installPlan}"
-              if [ ! -z "${installPlan}" ]; then
-                echo
-                echo "Check InstallPlan (${installPlan}) approval"
-                if installPlanApproved=$(oc get installplan ${installPlan} -o=jsonpath="{.spec.approved}"); then
-                  if [ "${installPlanApproved}" == "false" ]; then
-                    echo "Approving InstallPlan (${installPlan})"
-                    oc patch installplan ${installPlan} --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
-                  else
-                    echo "InstallPlan (${installPlan})already approved"
-                  fi
-                  exit 0
-                else
-                  echo "Failed to look up InstallPlan (${installPlan}) approval"
-                  exit 1
-                fi
-              else
-                echo
-                echo "Could not find InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner. This can happen if InstallPlan isn't created yet. Try again."
+                exit 0
+              fi
+
+              # 3. track mode: approve whatever OLM resolved from the channel
+              #    (the head), regardless of whether it equals the pin.
+              if [ "${PIN_POLICY}" = "track" ] && [ -n "${anyPending}" ]; then
+                toApprove=$(echo "${anyPending}" | cut -d'|' -f1)
+                resolvedCSV=$(echo "${anyPending}" | cut -d'|' -f2)
+                echo "pinPolicy=track: approving InstallPlan ${toApprove} for catalog-resolved csv ${resolvedCSV} (pinned ${SUBSCRIPTION_CSV})"
+                oc patch installplan -n ${SUBSCRIPTION_NAMESPACE} ${toApprove} --type=json -p='[{"op":"replace","path":"/spec/approved","value":true}]'
+                exit 0
+              fi
+
+              # 3b. track mode + nothing pending but something is already
+              #     installed -> resting state (the channel head is in), nothing
+              #     to approve. Idempotent on every Argo re-sync.
+              if [ "${PIN_POLICY}" = "track" ] && [ -n "${installedCSV}" ]; then
+                echo "pinPolicy=track: installedCSV=${installedCSV}, no pending InstallPlan. Nothing to approve."
+                exit 0
+              fi
+
+              # 4. strict mode + the only pending InstallPlan is for a DIFFERENT csv
+              #    and the pin is NOT installed -> the catalog cannot give us the
+              #    pinned version. Fail LOUD with the exact mismatch instead of
+              #    silently spinning until the job deadline.
+              if [ "${PIN_POLICY}" != "track" ] && [ -n "${anyPending}" ]; then
+                resolvedCSV=$(echo "${anyPending}" | cut -d'|' -f2)
+                echo "ERROR (pinPolicy=strict): the pending InstallPlan for Subscription ${SUBSCRIPTION} is for csv '${resolvedCSV}', but the pinned csv is '${SUBSCRIPTION_CSV}' and it is not installed (installedCSV='${installedCSV}')."
+                echo "This usually means the catalog channel head has moved past the pinned csv, or the channel only offers an upgrade path that skips it."
+                echo "Remedy: bump this operator's 'csv' pin to '${resolvedCSV}' (recommended - keeps version control), or set 'pinPolicy: track' on this operator to auto-approve the channel head."
+                exit 2
+              fi
+
+              # 5. Nothing actionable yet (InstallPlan not created) -> bounded retry.
+              attempt=$((attempt+1))
+              if [ "${attempt}" -ge "${LOOKUP_ATTEMPTS}" ]; then
+                subState=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} ${SUBSCRIPTION} -o=jsonpath="{.status.state}")
+                echo "ERROR: no approvable InstallPlan for Subscription ${SUBSCRIPTION} after ${LOOKUP_ATTEMPTS} attempts (pinned csv '${SUBSCRIPTION_CSV}', state='${subState}', installedCSV='${installedCSV}'). Check the Subscription and its CatalogSource are healthy."
                 exit 1
               fi
-            else
-              echo
-              echo "Failed to get Subscription ($SUBSCRIPTION) UID. This really shouldn't happen."
-              exit 1
-            fi
+              echo "No approvable InstallPlan yet, retrying in 5 seconds... (${attempt}/${LOOKUP_ATTEMPTS})"
+              sleep 5
+            done
         imagePullPolicy: Always
         env:
         - name: SUBSCRIPTION_CSV
-          value: {{ .csv }}
+          value: {{ .csv | quote }}
         - name: SUBSCRIPTION
-          value: {{ .name }}
+          value: {{ .name | quote }}
+        - name: SUBSCRIPTION_NAMESPACE
+          value: {{ .namespace | default $.Release.Namespace | quote }}
+        - name: PIN_POLICY
+          value: {{ .pinPolicy | default "strict" | quote }}
+        - name: LOOKUP_ATTEMPTS
+          value: {{ .installPlanApproverLookupAttempts | default 36 | quote }}
       dnsPolicy: ClusterFirst
       restartPolicy: Never
       serviceAccount: {{ include "operators-installer.approverName" . }}

--- a/operators-installer/templates/installplan-approver/installplan-approver.yaml
+++ b/operators-installer/templates/installplan-approver/installplan-approver.yaml
@@ -28,112 +28,86 @@ spec:
             export HOME=/tmp/approver
             echo
 
-            # ----------------------------------------------------------------
-            # Resolve the Subscription UID (bounded retry).
-            # ----------------------------------------------------------------
-            subscriptionUID=""
+            # Read the fields OLM itself maintains on the Subscription:
+            #   .status.installedCSV     - what is actually installed
+            #   .status.currentCSV       - the CSV OLM has resolved to install now
+            #   .status.installPlanRef   - the exact InstallPlan for THIS subscription
+            # Keying off these avoids guessing from InstallPlan ownerReferences /
+            # clusterServiceVersionNames, which for a bundled upgrade lists the
+            # operator's dependencies too (the operator's own CSV may not even be
+            # first in the list).
+            sub() { oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} ${SUBSCRIPTION} -o=jsonpath="$1" 2>/dev/null; }
+
+            echo "Reconciling Subscription ${SUBSCRIPTION} (pinned csv=${SUBSCRIPTION_CSV}, pinPolicy=${PIN_POLICY})"
             attempt=0
-            while [ -z "${subscriptionUID}" ]; do
-              echo "Get Subscription (${SUBSCRIPTION}) UID"
-              subscriptionUID=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} --field-selector metadata.name=${SUBSCRIPTION} -o=jsonpath="{.items[0].metadata.uid}")
-              if [ -z "${subscriptionUID}" ]; then
+            while true; do
+              if [ -z "$(sub '{.metadata.uid}')" ]; then
                 attempt=$((attempt+1))
                 if [ "${attempt}" -ge "${LOOKUP_ATTEMPTS}" ]; then
                   echo "ERROR: Subscription ${SUBSCRIPTION} not found after ${LOOKUP_ATTEMPTS} attempts."
                   exit 1
                 fi
-                echo "Subscription UID not found, retrying in 5 seconds... (${attempt}/${LOOKUP_ATTEMPTS})"
+                echo "Subscription not found yet, retrying in 5 seconds... (${attempt}/${LOOKUP_ATTEMPTS})"
                 sleep 5
-              fi
-            done
-            echo "Subscription (${SUBSCRIPTION}) UID: ${subscriptionUID}"
-
-            # ----------------------------------------------------------------
-            # go-template: emit one "name|csv|phase|approved" line per InstallPlan
-            # owned by this Subscription (ANY csv). Unlike the previous version
-            # this does NOT filter on the pinned csv, so the selection logic below
-            # is robust to the catalog channel head having moved past the pin.
-            # NOTE: nested in {{`  `}} so helm does not interpret the go template;
-            #       go-template vars are written \$var, shell vars stay ${var}.
-            # ----------------------------------------------------------------
-            {{`ownedInstallPlansGoTemplate=$(cat << EOF
-            {{- range .items -}}{{- \$ip := . -}}{{- range \$ip.metadata.ownerReferences -}}{{- if eq .uid "${subscriptionUID}" -}}{{ \$ip.metadata.name }}|{{ index \$ip.spec.clusterServiceVersionNames 0 }}|{{ \$ip.status.phase }}|{{ \$ip.spec.approved }}
-            {{ end -}}{{- end -}}{{- end -}}
-            EOF
-            )`}}
-
-            echo
-            echo "Reconciling InstallPlans for Subscription ${SUBSCRIPTION} (pinned csv=${SUBSCRIPTION_CSV}, pinPolicy=${PIN_POLICY})"
-            attempt=0
-            while true; do
-              # strip go-template indentation whitespace (fields never contain spaces)
-              owned=$(oc get installplan -n ${SUBSCRIPTION_NAMESPACE} -o=go-template="${ownedInstallPlansGoTemplate}" | tr -d ' ')
-              installedCSV=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} ${SUBSCRIPTION} -o=jsonpath="{.status.installedCSV}")
-
-              # a pending InstallPlan for the PINNED csv (initial install of the pin)
-              pinnedPending=$(echo "${owned}" | grep -F "|${SUBSCRIPTION_CSV}|RequiresApproval|" | head -n1)
-              # any pending InstallPlan owned by this Subscription (channel head / upgrade)
-              anyPending=$(echo "${owned}" | grep -F "|RequiresApproval|" | head -n1)
-
-              # 1. The pinned version is offered and pending -> approve it.
-              if [ -n "${pinnedPending}" ]; then
-                toApprove=$(echo "${pinnedPending}" | cut -d'|' -f1)
-                echo "Approving InstallPlan ${toApprove} for pinned csv ${SUBSCRIPTION_CSV}"
-                oc patch installplan -n ${SUBSCRIPTION_NAMESPACE} ${toApprove} --type=json -p='[{"op":"replace","path":"/spec/approved","value":true}]'
-                exit 0
+                continue
               fi
 
-              # 2. The pin is already installed -> nothing to do. Any other pending
-              #    InstallPlan is an un-approved upgrade we intentionally leave
-              #    pending: that is the whole point of a Manual pin. Idempotent on
-              #    every Argo re-sync.
+              installedCSV=$(sub '{.status.installedCSV}')
+              currentCSV=$(sub '{.status.currentCSV}')
+              ipName=$(sub '{.status.installPlanRef.name}')
+
+              # 1. Pin already installed -> nothing to do. A newer pending
+              #    InstallPlan is intentionally left unapproved (that is the point
+              #    of a Manual pin). Idempotent on every Argo re-sync.
               if [ "${installedCSV}" = "${SUBSCRIPTION_CSV}" ]; then
                 echo "Pinned csv ${SUBSCRIPTION_CSV} already installed. Nothing to approve."
-                if [ -n "${anyPending}" ]; then
-                  echo "NOTE: a newer InstallPlan is pending but is intentionally left unapproved (Manual pin)."
+                exit 0
+              fi
+
+              # 2. Wait for OLM to designate an InstallPlan for this Subscription.
+              if [ -z "${ipName}" ]; then
+                attempt=$((attempt+1))
+                if [ "${attempt}" -ge "${LOOKUP_ATTEMPTS}" ]; then
+                  echo "ERROR: Subscription ${SUBSCRIPTION} has no installPlanRef after ${LOOKUP_ATTEMPTS} attempts (state='$(sub '{.status.state}')', installedCSV='${installedCSV}', currentCSV='${currentCSV}'). Check the Subscription and its CatalogSource are healthy."
+                  exit 1
                 fi
+                echo "No installPlanRef yet, retrying in 5 seconds... (${attempt}/${LOOKUP_ATTEMPTS})"
+                sleep 5
+                continue
+              fi
+
+              ipApproved=$(oc get installplan -n ${SUBSCRIPTION_NAMESPACE} ${ipName} -o=jsonpath="{.spec.approved}" 2>/dev/null)
+              echo "Subscription ${SUBSCRIPTION}: installedCSV='${installedCSV}' currentCSV='${currentCSV}' installPlanRef='${ipName}' (approved='${ipApproved}')"
+
+              # 3. OLM resolved the PINNED csv -> approve its InstallPlan.
+              if [ "${currentCSV}" = "${SUBSCRIPTION_CSV}" ]; then
+                if [ "${ipApproved}" = "true" ]; then
+                  echo "InstallPlan ${ipName} for pinned csv ${SUBSCRIPTION_CSV} already approved."
+                  exit 0
+                fi
+                echo "Approving InstallPlan ${ipName} for pinned csv ${SUBSCRIPTION_CSV}"
+                oc patch installplan -n ${SUBSCRIPTION_NAMESPACE} ${ipName} --type=json -p='[{"op":"replace","path":"/spec/approved","value":true}]'
                 exit 0
               fi
 
-              # 3. track mode: approve whatever OLM resolved from the channel
-              #    (the head), regardless of whether it equals the pin.
-              if [ "${PIN_POLICY}" = "track" ] && [ -n "${anyPending}" ]; then
-                toApprove=$(echo "${anyPending}" | cut -d'|' -f1)
-                resolvedCSV=$(echo "${anyPending}" | cut -d'|' -f2)
-                echo "pinPolicy=track: approving InstallPlan ${toApprove} for catalog-resolved csv ${resolvedCSV} (pinned ${SUBSCRIPTION_CSV})"
-                oc patch installplan -n ${SUBSCRIPTION_NAMESPACE} ${toApprove} --type=json -p='[{"op":"replace","path":"/spec/approved","value":true}]'
+              # 4. OLM resolved a DIFFERENT csv than the pin and the pin is not
+              #    installed.
+              if [ "${PIN_POLICY}" = "track" ]; then
+                if [ "${ipApproved}" = "true" ]; then
+                  echo "pinPolicy=track: InstallPlan ${ipName} (csv ${currentCSV}) already approved."
+                  exit 0
+                fi
+                echo "pinPolicy=track: approving InstallPlan ${ipName} for catalog-resolved csv ${currentCSV} (pinned ${SUBSCRIPTION_CSV})"
+                oc patch installplan -n ${SUBSCRIPTION_NAMESPACE} ${ipName} --type=json -p='[{"op":"replace","path":"/spec/approved","value":true}]'
                 exit 0
               fi
 
-              # 3b. track mode + nothing pending but something is already
-              #     installed -> resting state (the channel head is in), nothing
-              #     to approve. Idempotent on every Argo re-sync.
-              if [ "${PIN_POLICY}" = "track" ] && [ -n "${installedCSV}" ]; then
-                echo "pinPolicy=track: installedCSV=${installedCSV}, no pending InstallPlan. Nothing to approve."
-                exit 0
-              fi
-
-              # 4. strict mode + the only pending InstallPlan is for a DIFFERENT csv
-              #    and the pin is NOT installed -> the catalog cannot give us the
-              #    pinned version. Fail LOUD with the exact mismatch instead of
-              #    silently spinning until the job deadline.
-              if [ "${PIN_POLICY}" != "track" ] && [ -n "${anyPending}" ]; then
-                resolvedCSV=$(echo "${anyPending}" | cut -d'|' -f2)
-                echo "ERROR (pinPolicy=strict): the pending InstallPlan for Subscription ${SUBSCRIPTION} is for csv '${resolvedCSV}', but the pinned csv is '${SUBSCRIPTION_CSV}' and it is not installed (installedCSV='${installedCSV}')."
-                echo "This usually means the catalog channel head has moved past the pinned csv, or the channel only offers an upgrade path that skips it."
-                echo "Remedy: bump this operator's 'csv' pin to '${resolvedCSV}' (recommended - keeps version control), or set 'pinPolicy: track' on this operator to auto-approve the channel head."
-                exit 2
-              fi
-
-              # 5. Nothing actionable yet (InstallPlan not created) -> bounded retry.
-              attempt=$((attempt+1))
-              if [ "${attempt}" -ge "${LOOKUP_ATTEMPTS}" ]; then
-                subState=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} ${SUBSCRIPTION} -o=jsonpath="{.status.state}")
-                echo "ERROR: no approvable InstallPlan for Subscription ${SUBSCRIPTION} after ${LOOKUP_ATTEMPTS} attempts (pinned csv '${SUBSCRIPTION_CSV}', state='${subState}', installedCSV='${installedCSV}'). Check the Subscription and its CatalogSource are healthy."
-                exit 1
-              fi
-              echo "No approvable InstallPlan yet, retrying in 5 seconds... (${attempt}/${LOOKUP_ATTEMPTS})"
-              sleep 5
+              # strict + skew: fail LOUD with the exact mismatch instead of
+              # silently spinning until the job deadline.
+              echo "ERROR (pinPolicy=strict): OLM resolved currentCSV='${currentCSV}' for Subscription ${SUBSCRIPTION}, but the pinned csv is '${SUBSCRIPTION_CSV}' and it is not installed (installedCSV='${installedCSV}')."
+              echo "The catalog channel does not offer the pinned csv on the current upgrade path (its head has moved on)."
+              echo "Remedy: bump this operator's 'csv' pin to '${currentCSV}' (recommended - keeps version control), or set 'pinPolicy: track' on this operator to auto-approve the channel head."
+              exit 2
             done
         imagePullPolicy: Always
         env:

--- a/operators-installer/templates/installplan-approver/installplan-complete-verifier.yaml
+++ b/operators-installer/templates/installplan-approver/installplan-complete-verifier.yaml
@@ -27,74 +27,74 @@ spec:
           - |
             export HOME=/tmp/approver
             echo
+
+            # Resolve the Subscription UID (bounded retry).
             subscriptionUID=""
+            attempt=0
             while [ -z "${subscriptionUID}" ]; do
               echo "Get Subscription (${SUBSCRIPTION}) UID"
-              subscriptionUID=$(oc get subscriptions.operators.coreos.com --field-selector metadata.name=${SUBSCRIPTION} -o=jsonpath="{.items[0].metadata.uid}")
+              subscriptionUID=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} --field-selector metadata.name=${SUBSCRIPTION} -o=jsonpath="{.items[0].metadata.uid}")
               if [ -z "${subscriptionUID}" ]; then
-                echo "Subscription UID not found, retrying in 5 seconds..."
-                sleep 5
+                attempt=$((attempt+1))
+                if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
+                  echo "ERROR: Subscription ${SUBSCRIPTION} not found after ${MAX_ATTEMPTS} attempts."
+                  exit 1
+                fi
+                echo "Subscription UID not found, retrying in ${SLEEP_TIMER} seconds... (${attempt}/${MAX_ATTEMPTS})"
+                sleep "${SLEEP_TIMER}"
               fi
             done
             echo "Subscription (${SUBSCRIPTION}) UID: ${subscriptionUID}"
-            if [ ! -z "subscriptionUID" ]; then
-              # this complicated go-template finds an InstallPlan where both the .spec.clusterServiceVersionNames contains the expected CSV
-              # and .metadata.ownerReferences contains the expected Subscription owner. JsonPath doesn't let you do and statements and go-templates
-              # done seem to have a function for checking if a value is in an array without iterating. so here we are.
-              # NOTE 1: if for whatever reason multiple InstallPlans are found that are associated with the Subscription for the correct CSV, only the first will be approved
-              # NOTE 2: this is nested in {{` `}} so that helm doesn't try to interpret the go template
-              {{`installPlanGoTemplate=$(cat << EOF
-              {{- \$installPlanName := "" -}}
-              {{- range .items -}}
-                {{- \$installPlanItem := . -}}
-                {{- range .spec.clusterServiceVersionNames -}}
-                  {{- if and (eq . "${SUBSCRIPTION_CSV}") (not \$installPlanName) -}}
-                    {{- range \$installPlanItem.metadata.ownerReferences -}}
-                      {{- if eq .uid "${subscriptionUID}" -}}
-                        {{- \$installPlanName = \$installPlanItem.metadata.name -}}
-                      {{- end -}}
-                    {{- end -}}
-                  {{- end -}}
-                {{- end -}}
-              {{- end -}}
-              {{ \$installPlanName }}
-            EOF
-              )`}}
-              echo
-              installPlan=""
-              while [ -z "${installPlan}" ]; do
-                echo "Get InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner"
-                installPlan=$(oc get installplan -o=go-template="${installPlanGoTemplate}")
-                if [ -z "${installPlan}" ]; then
-                  echo "InstallPlan not found, retrying in 5 seconds..."
-                  sleep 5
-                fi
-              done
-              echo "InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner: ${installPlan}"
-              
-              installPlanPhase=""
-              while [ "${installPlanPhase}" != "Complete" ]; do
-                echo "Checking InstallPlan (${installPlan}) phase"
-                installPlanPhase=$(oc get installplan ${installPlan} -o=jsonpath="{.status.phase}")
-                if [ "${installPlanPhase}" == "Complete" ]; then
-                  echo "InstallPlan (${installPlan}) is complete"
-                else
-                  echo "InstallPlan (${installPlan}) not yet complete: ${installPlanPhase}, retrying in 5 seconds..."
-                  sleep 5
-                fi
-              done
-              exit 0
-            else
-              echo
-              echo "Failed to get Subscription ($SUBSCRIPTION) UID. This really shouldn't happen."
-              exit 1
+
+            # Which csv's InstallPlan must complete? strict -> pin; track -> the
+            # csv the Subscription actually resolved to (status.installedCSV).
+            targetCSV="${SUBSCRIPTION_CSV}"
+            if [ "${PIN_POLICY}" = "track" ]; then
+              targetCSV=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} ${SUBSCRIPTION} -o=jsonpath="{.status.installedCSV}")
+              [ -z "${targetCSV}" ] && targetCSV="${SUBSCRIPTION_CSV}"
             fi
+            echo "Waiting for the InstallPlan of csv ${targetCSV} (Subscription ${SUBSCRIPTION}) to reach Complete"
+
+            # go-template: emit "name|csv|phase" for each InstallPlan owned by
+            # this Subscription. (See installplan-approver.yaml for the escaping.)
+            {{`ownedInstallPlansGoTemplate=$(cat << EOF
+            {{- range .items -}}{{- \$ip := . -}}{{- range \$ip.metadata.ownerReferences -}}{{- if eq .uid "${subscriptionUID}" -}}{{ \$ip.metadata.name }}|{{ index \$ip.spec.clusterServiceVersionNames 0 }}|{{ \$ip.status.phase }}
+            {{ end -}}{{- end -}}{{- end -}}
+            EOF
+            )`}}
+
+            attempt=0
+            while true; do
+              # strip go-template indentation whitespace (fields never contain spaces)
+              owned=$(oc get installplan -n ${SUBSCRIPTION_NAMESPACE} -o=go-template="${ownedInstallPlansGoTemplate}" | tr -d ' ')
+              line=$(echo "${owned}" | grep -F "|${targetCSV}|" | head -n1)
+              phase=$(echo "${line}" | cut -d'|' -f3)
+              if [ "${phase}" = "Complete" ]; then
+                echo "InstallPlan for csv ${targetCSV} is Complete."
+                exit 0
+              fi
+              attempt=$((attempt+1))
+              if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
+                echo "Giving up. InstallPlan for csv ${targetCSV} did not reach Complete (last phase: '${phase}')."
+                exit 3
+              fi
+              echo "InstallPlan for csv ${targetCSV} phase: '${phase}' (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${SLEEP_TIMER} seconds..."
+              sleep "${SLEEP_TIMER}"
+            done
         imagePullPolicy: Always
         env:
         - name: SUBSCRIPTION_CSV
-          value: {{ .csv }}
+          value: {{ .csv | quote }}
         - name: SUBSCRIPTION
-          value: {{ .name }}
+          value: {{ .name | quote }}
+        - name: SUBSCRIPTION_NAMESPACE
+          value: {{ .namespace | default $.Release.Namespace | quote }}
+        - name: PIN_POLICY
+          value: {{ .pinPolicy | default "strict" | quote }}
+        - name: MAX_ATTEMPTS
+          value: {{ .installPlanVerifierAttempts | default 60 | quote }}
+        - name: SLEEP_TIMER
+          value: {{ .installPlanVerifierSleepSeconds | default 5 | quote }}
       dnsPolicy: ClusterFirst
       restartPolicy: Never
       serviceAccount: {{ include "operators-installer.approverName" . }}

--- a/operators-installer/templates/installplan-approver/installplan-complete-verifier.yaml
+++ b/operators-installer/templates/installplan-approver/installplan-complete-verifier.yaml
@@ -27,58 +27,35 @@ spec:
           - |
             export HOME=/tmp/approver
             echo
+            sub() { oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} ${SUBSCRIPTION} -o=jsonpath="$1" 2>/dev/null; }
 
-            # Resolve the Subscription UID (bounded retry).
-            subscriptionUID=""
-            attempt=0
-            while [ -z "${subscriptionUID}" ]; do
-              echo "Get Subscription (${SUBSCRIPTION}) UID"
-              subscriptionUID=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} --field-selector metadata.name=${SUBSCRIPTION} -o=jsonpath="{.items[0].metadata.uid}")
-              if [ -z "${subscriptionUID}" ]; then
-                attempt=$((attempt+1))
-                if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
-                  echo "ERROR: Subscription ${SUBSCRIPTION} not found after ${MAX_ATTEMPTS} attempts."
-                  exit 1
-                fi
-                echo "Subscription UID not found, retrying in ${SLEEP_TIMER} seconds... (${attempt}/${MAX_ATTEMPTS})"
-                sleep "${SLEEP_TIMER}"
-              fi
-            done
-            echo "Subscription (${SUBSCRIPTION}) UID: ${subscriptionUID}"
-
-            # Which csv's InstallPlan must complete? strict -> pin; track -> the
-            # csv the Subscription actually resolved to (status.installedCSV).
-            targetCSV="${SUBSCRIPTION_CSV}"
-            if [ "${PIN_POLICY}" = "track" ]; then
-              targetCSV=$(oc get subscriptions.operators.coreos.com -n ${SUBSCRIPTION_NAMESPACE} ${SUBSCRIPTION} -o=jsonpath="{.status.installedCSV}")
-              [ -z "${targetCSV}" ] && targetCSV="${SUBSCRIPTION_CSV}"
-            fi
-            echo "Waiting for the InstallPlan of csv ${targetCSV} (Subscription ${SUBSCRIPTION}) to reach Complete"
-
-            # go-template: emit "name|csv|phase" for each InstallPlan owned by
-            # this Subscription. (See installplan-approver.yaml for the escaping.)
-            {{`ownedInstallPlansGoTemplate=$(cat << EOF
-            {{- range .items -}}{{- \$ip := . -}}{{- range \$ip.metadata.ownerReferences -}}{{- if eq .uid "${subscriptionUID}" -}}{{ \$ip.metadata.name }}|{{ index \$ip.spec.clusterServiceVersionNames 0 }}|{{ \$ip.status.phase }}
-            {{ end -}}{{- end -}}{{- end -}}
-            EOF
-            )`}}
-
+            echo "Waiting for the InstallPlan of Subscription ${SUBSCRIPTION} to reach Complete (pinned csv=${SUBSCRIPTION_CSV}, pinPolicy=${PIN_POLICY})"
             attempt=0
             while true; do
-              # strip go-template indentation whitespace (fields never contain spaces)
-              owned=$(oc get installplan -n ${SUBSCRIPTION_NAMESPACE} -o=go-template="${ownedInstallPlansGoTemplate}" | tr -d ' ')
-              line=$(echo "${owned}" | grep -F "|${targetCSV}|" | head -n1)
-              phase=$(echo "${line}" | cut -d'|' -f3)
-              if [ "${phase}" = "Complete" ]; then
-                echo "InstallPlan for csv ${targetCSV} is Complete."
+              installedCSV=$(sub '{.status.installedCSV}')
+              # In strict mode the pin being installed is success, regardless of any
+              # newer pending upgrade InstallPlan that is intentionally left unapproved.
+              if [ "${PIN_POLICY}" != "track" ] && [ "${installedCSV}" = "${SUBSCRIPTION_CSV}" ]; then
+                echo "Pinned csv ${SUBSCRIPTION_CSV} is installed."
                 exit 0
               fi
+
+              # Otherwise track the InstallPlan OLM designated for this Subscription.
+              ipName=$(sub '{.status.installPlanRef.name}')
+              if [ -n "${ipName}" ]; then
+                phase=$(oc get installplan -n ${SUBSCRIPTION_NAMESPACE} ${ipName} -o=jsonpath="{.status.phase}" 2>/dev/null)
+                if [ "${phase}" = "Complete" ]; then
+                  echo "InstallPlan ${ipName} (currentCSV $(sub '{.status.currentCSV}')) is Complete."
+                  exit 0
+                fi
+              fi
+
               attempt=$((attempt+1))
               if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
-                echo "Giving up. InstallPlan for csv ${targetCSV} did not reach Complete (last phase: '${phase}')."
+                echo "Giving up. InstallPlan '${ipName}' for Subscription ${SUBSCRIPTION} did not reach Complete (last phase: '${phase}', installedCSV='${installedCSV}', currentCSV='$(sub '{.status.currentCSV}')')."
                 exit 3
               fi
-              echo "InstallPlan for csv ${targetCSV} phase: '${phase}' (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${SLEEP_TIMER} seconds..."
+              echo "InstallPlan '${ipName}' phase: '${phase}' (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${SLEEP_TIMER} seconds..."
               sleep "${SLEEP_TIMER}"
             done
         imagePullPolicy: Always

--- a/operators-installer/values.yaml
+++ b/operators-installer/values.yaml
@@ -19,6 +19,24 @@ annotations:
 ## Both Helm are argo hooks are defined . as per docs . If you define some Argo CD hooks in addition to the Helm ones, the Helm hooks will be ignored.
 ## https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks
 
+# Per-operator manual-approval knobs (all optional):
+#
+#   pinPolicy: strict | track   (default: strict)
+#     strict - only the pinned `csv` is approved/verified. If the catalog
+#              channel head has moved past the pin and the pin is not
+#              installed, the approver FAILS LOUD with the exact mismatch
+#              (pinned vs catalog-offered csv) instead of silently spinning
+#              until the job deadline. A pending upgrade InstallPlan while the
+#              pin IS installed is intentionally left unapproved (that is the
+#              point of a Manual pin) and the approver exits 0.
+#     track  - approve/verify whatever OLM resolved from the channel (the head),
+#              regardless of whether it equals `csv`. Use when you want
+#              gated-but-current rather than a hard version pin.
+#
+#   installPlanApproverLookupAttempts: 36   # 5s each ~= 3 min before failing loud
+#   installPlanVerifierAttempts: 60         # attempts for the csv/complete verifiers
+#   installPlanVerifierSleepSeconds: 5      # sleep between verifier attempts
+#
 # EXAMPLE: declaratively controlled operator version
 operators:
 # - channel: stable
@@ -27,6 +45,7 @@ operators:
 #   source: community-operators
 #   sourceNamespace: openshift-marketplace
 #   csv: external-secrets-operator.v0.8.2
+#   pinPolicy: strict
 # - channel: gitops-1.10
 #   installPlanApproval: Manual
 #   name: openshift-gitops-operator


### PR DESCRIPTION
## Problem

The `operators-installer` manual-approval flow hangs and dies with a vague timeout when the catalog channel head moves past the chart's pinned `.csv` (root cause behind **SA-8608**).

- The approver matched an InstallPlan **only if its CSV exactly equaled the pinned `.csv`**, then spun in a `while [ -z "${installPlan}" ]` loop until `activeDeadlineSeconds` killed the Job.
- `subscription.yaml` sets `startingCSV: {{ .csv }}`, but OLM honors `startingCSV` **only on a fresh install**. Once an operator is installed, OLM's upgrade InstallPlans track the **channel head** — which the exact-CSV approver can never match. Result: silent 10-minute timeout, no actionable signal.
- Separately, `csv-verifier.yaml` referenced `$max_timer` / `$sleep_timer` that were **never set**, so it busy-looped and only ever terminated via the job deadline.

## Fix

Make approve/verify **Subscription-driven**. Instead of scanning InstallPlans for an exact CSV string, read the fields OLM maintains on the Subscription — `.status.installedCSV`, `.status.currentCSV`, `.status.installPlanRef` — which is also correct when an upgrade InstallPlan bundles the operator's dependencies (the operator's own CSV need not be first, or present, in `clusterServiceVersionNames`).

**Approver** decides:
| state | action |
|---|---|
| pin already installed | noop; a newer pending plan is intentionally left unapproved (Manual pin) |
| `currentCSV` == pin | approve its `installPlanRef` (initial install / upgrade to the pin) |
| `currentCSV` != pin & pin not installed, **strict** | **fail loud** with the exact `currentCSV` vs pinned mismatch + remedy (no silent deadline) |
| `currentCSV` != pin & pin not installed, **track** | approve `installPlanRef` (the channel head) |

**Verifiers** (`csv-verifier`, `installplan-complete-verifier`): in `strict` they verify the pinned csv / that the pin is installed; in `track` they follow the Subscription's `currentCSV` (the version being installed — not `installedCSV`, which is the old version until the upgrade completes) / `installPlanRef`. Both now have **bounded, self-terminating** retry loops with clear give-up messages.

## New per-operator values (optional; defaults preserve current strict behaviour)

- `pinPolicy`: `strict` (default) | `track`
- `installPlanApproverLookupAttempts` (default 36 ≈ 3 min)
- `installPlanVerifierAttempts` (default 60), `installPlanVerifierSleepSeconds` (default 5)

## Validation

- `helm lint` + `helm template` clean; only Manual operators get the Jobs; defaults keep existing strict behaviour.
- Decision logic simulated across every branch before the live test: fresh install, pinned + pending-upgrade steady state, strict skew fail-loud, track approve, track resting-state noop, retry.

## Verified end-to-end on live OLM

Tested against the stuck `tenant-operator` on hosted cluster **y0c8muex** (us-2), real state:
`installedCSV=v1.7.0`, `currentCSV=v1.8.3` (channel head), pin `v1.8.1` — the exact SA-8608 skew (the shipped approver Job had been **Failed for ~5 days**).

- **strict (default):** exits `2` in seconds with the precise diagnostic — `OLM resolved currentCSV='tenant-operator.v1.8.3' ... pinned csv is 'tenant-operator.v1.8.1' and it is not installed (installedCSV='tenant-operator.v1.7.0')` + remedy. No more silent 10-min timeout.
- **track:** patched the Subscription's `installPlanRef` (`install-g6mz9`) to approved → OLM installed `v1.8.3` → CSV `Succeeded`, subscription `AtLatestKnown`.
- Correctly used `status.installPlanRef`/`currentCSV` where the InstallPlan bundled a dependency (`csvs=[mto-dependencies-operator.v0.0.12, tenant-operator.v1.8.3]`) — the case that defeats CSV-array guessing.

Note: this fixes the approver *behaviour*. The stale pin itself is the separate SA-8608 follow-up (bump `csv` to v1.8.3, or migrate the MTO operators to a Stakater-owned CatalogSource).
