### PR TITLE
docs(crossplane-observability): make manageAlerts a durable platform edit

### DIFF
--- a/crossplane-observability/Chart.yaml
+++ b/crossplane-observability/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crossplane-observability
 description: A Helm chart for Crossplane observability (ServiceMonitor + PrometheusRule + Grafana dashboard), integrated with OpenShift user-workload monitoring.
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.0.1"

--- a/crossplane-observability/README.md
+++ b/crossplane-observability/README.md
@@ -193,6 +193,13 @@ These need cluster/Grafana context an agent can't safely guess:
    Without it, the Alert list shows only the Grafana-managed alerts; the "Alerts firing" stat
    (which reads the `ALERTS` metric) still works regardless — **a count there with an empty list
    means this toggle is off** (confirmed in the 2026-06-16 deploy validation).
+
+   > **This datasource is not owned by this chart — make the edit durable.** The Prometheus/Thanos
+   > `GrafanaDatasource` is a platform resource (its namespace varies per cluster — e.g.
+   > `stakater-grafana-operator` in the standard layout, or the grafana-operator's own namespace).
+   > Set `manageAlerts` in that datasource's **source manifest** (the GitOps/bootstrap repo that
+   > applies it), not with a live `kubectl patch` — a patch survives an in-place `kubectl apply` but
+   > is lost if the datasource is ever deleted and recreated from a source that omits the field.
 4. **Confirm the inventory exporter** (`crossplane.inventory.{conditionMetricPattern,job}`) by
    scraping it (`tests/fetch-cluster-metrics.sh`) before trusting Story 4.1.
 5. **Calibrate thresholds** over 2–4 weeks of baseline before treating any SLA number as real.


### PR DESCRIPTION
## What

The dashboard's unified **Alert list** panel needs `jsonData.manageAlerts: true` on the Prometheus/Thanos `GrafanaDatasource` to show the Prometheus/UWM alerts (README SRE step 3b). This clarifies how to make that setting **durable**.

## Why

Investigation on us-2 (Task 6 of the DoD follow-up):

- `manageAlerts: true` is still live 6 days after the 07-16 fix (field-manager `kubectl-patch`).
- The `prometheus-uwm` datasource is **not** GitOps-managed — none of the 141 ArgoCD apps manage a `GrafanaDatasource` or target its namespace; no Flux, no ownerReferences, no Argo tracking labels. It's applied by a plain `kubectl apply`.
- Because `manageAlerts` was never in the datasource's `last-applied-configuration`, a re-`kubectl apply` of the source manifest 3-way-merges and **keeps** it — so the earlier "reverts on GitOps resync" premise was wrong.
- The only real reversion risk is the datasource being deleted/recreated from a source manifest that omits the field.

This datasource is a **platform resource, not owned by this chart**, so there is no chart-code fix — only documentation. The note also records that the datasource/operator namespace varies per cluster (e.g. `stakater-grafana-operator` in the standard layout).

## Changes

- README step 3b: add a callout that `manageAlerts` must be set in the datasource's **source manifest** (not via a live `kubectl patch`), and that the namespace varies per cluster.
- Bump chart `version` 0.1.3 → 0.1.4.

## Testing

- `helm lint` clean (icon INFO only)
- `./tests/validate.sh` green (docs-only change; render/rules unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)