### PR TITLE
fix(crossplane-observability): match all provider pods in Provider dashboard panels

### DIFF
--- a/crossplane-observability/Chart.yaml
+++ b/crossplane-observability/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crossplane-observability
 description: A Helm chart for Crossplane observability (ServiceMonitor + PrometheusRule + Grafana dashboard), integrated with OpenShift user-workload monitoring.
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.0.1"

--- a/crossplane-observability/files/crossplane_grafana_dashboard.json
+++ b/crossplane-observability/files/crossplane_grafana_dashboard.json
@@ -1580,7 +1580,7 @@
             "uid": "${datasource}"
           },
           "legendFormat": "{{pod}}",
-          "expr": "increase(kube_pod_container_status_restarts_total{pod=~\"provider.*\"}[1h])"
+          "expr": "increase(kube_pod_container_status_restarts_total{pod=~\".*provider.*\"}[1h])"
         }
       ]
     },
@@ -1616,7 +1616,7 @@
             "uid": "${datasource}"
           },
           "legendFormat": "{{pod}}",
-          "expr": "sum by (pod) (container_memory_working_set_bytes{pod=~\"provider.*\", container!=\"\"})"
+          "expr": "sum by (pod) (container_memory_working_set_bytes{pod=~\".*provider.*\", container!=\"\"})"
         }
       ]
     },
@@ -1672,7 +1672,7 @@
             "uid": "${datasource}"
           },
           "legendFormat": "{{pod}}",
-          "expr": "rate(container_cpu_cfs_throttled_periods_total{pod=~\"provider.*\", container!=\"\"}[5m]) / clamp_min(rate(container_cpu_cfs_periods_total{pod=~\"provider.*\", container!=\"\"}[5m]), 1)"
+          "expr": "rate(container_cpu_cfs_throttled_periods_total{pod=~\".*provider.*\", container!=\"\"}[5m]) / clamp_min(rate(container_cpu_cfs_periods_total{pod=~\".*provider.*\", container!=\"\"}[5m]), 1)"
         }
       ]
     },


### PR DESCRIPTION
## What

The three **Provider …** panels on the Crossplane dashboard used a start-anchored pod selector `pod=~"provider.*"`. Widen all three to `pod=~".*provider.*"`:

| Line | Panel | Metric |
|------|-------|--------|
| 1583 | Provider pod restarts | `kube_pod_container_status_restarts_total` |
| 1619 | Provider memory working set | `container_memory_working_set_bytes` |
| 1675 | Provider CPU throttled % | `container_cpu_cfs_{throttled_,}periods_total` |

## Why

`provider.*` is start-anchored (PromQL regex matches are fully anchored), so it only matches pods literally prefixed `provider-` — the upjet `provider-<x>` pods. Providers installed as `<name>-crossplane-provider-…` (e.g. `netbird-crossplane-provider-…`) never match. Effect observed in the Task 8 panel-by-panel no-data audit on us-2:

- **Provider CPU throttled %** returned **no data at all** — both the metric and the pods exist, the selector just matched nothing.
- **Provider pod restarts** / **Provider memory working set** used the same anchored selector and **silently under-counted**, showing only the `provider-`-prefixed pods (25/24 series) while missing the `*-crossplane-provider-*` ones.

Widening to `.*provider.*` is a strict superset — it can only add matching provider pods, and the panels are titled "Provider …" so matching every pod with `provider` in the name is the intent.

## Testing

`./tests/validate.sh` green: dashboard JSON valid + panel ids unique, all 39 panel PromQL queries parse, 24 rendered objects valid against their CRD schemas, helm lint clean.

Follow-up to #274; closes the one bug from the Task 8 audit (tracked under #283).

🤖 Generated with [Claude Code](https://claude.com/claude-code)