### PR TITLE
fix(operators-installer): omit startingCSV under pinPolicy track

### DIFF
--- a/operators-installer/templates/subscription.yaml
+++ b/operators-installer/templates/subscription.yaml
@@ -18,5 +18,19 @@ spec:
   name: "{{ .name }}"
   source: "{{ .source }}"
   sourceNamespace: "{{ .sourceNamespace }}"
+  {{- /*
+    startingCSV pins OLM's *resolver*, not just the approval step. Emitting it
+    under pinPolicy: track defeats the whole point of track: if the pinned build
+    is absent from this cluster's catalog, the Subscription fails resolution
+    (`ResolutionFailed: no operators found with name <csv> in channel <ch>`), no
+    InstallPlan is ever created, and the approver/verifier Jobs spin until their
+    deadline — the operator never installs. That is exactly how an OCP-coupled
+    pin (e.g. a v4.21 VPA build on a 4.20 cluster) wedges. Under track we want
+    OLM to resolve the channel head, so omit startingCSV and let the approver
+    gate the resulting InstallPlan instead. `csv` stays meaningful under track as
+    the documented baseline/intent, it just no longer constrains the resolver.
+  */}}
+  {{- if and .csv (ne (.pinPolicy | default "strict") "track") }}
   startingCSV: "{{ .csv }}"
+  {{- end }}
 {{- end }}

--- a/operators-installer/values.yaml
+++ b/operators-installer/values.yaml
@@ -32,6 +32,15 @@ annotations:
 #     track  - approve/verify whatever OLM resolved from the channel (the head),
 #              regardless of whether it equals `csv`. Use when you want
 #              gated-but-current rather than a hard version pin.
+#              track also OMITS `startingCSV` from the Subscription, because
+#              startingCSV constrains OLM's *resolver*: leaving it set makes the
+#              Subscription fail resolution outright (ResolutionFailed -> no
+#              InstallPlan -> approver spins to its deadline) whenever the pinned
+#              build is absent from this cluster's catalog. That is what makes
+#              track the correct choice for operators whose builds are tied to
+#              the cluster's OCP minor, since the catalog only carries builds for
+#              the running release train. Under track, `csv` is retained purely
+#              as documentation of the intended baseline.
 #
 #   installPlanApproverLookupAttempts: 36   # 5s each ~= 3 min before failing loud
 #   installPlanVerifierAttempts: 60         # attempts for the csv/complete verifiers


### PR DESCRIPTION
## Problem

`pinPolicy: track` (shipped in 1.0.8) documents itself as *"approve/verify whatever OLM resolved from the channel (the head), regardless of whether it equals `csv`"* — but `templates/subscription.yaml` emitted **`startingCSV` unconditionally**.

`startingCSV` constrains OLM's **resolver**, not just the approval step. So whenever the pinned build isn't in the cluster's catalog, `track` could never engage:

```
Subscription: ResolutionFailed
  constraints not satisfiable: no operators found with name
  vertical-pod-autoscaler.v4.21.0-202604221819 in channel stable
  of package vertical-pod-autoscaler
```

→ no InstallPlan is ever created → the approver/verifier Jobs poll for an InstallPlan that never appears until `activeDeadlineSeconds` → **the operator silently never installs**.

## Real-world case

Found on scobasic HC **y0c8muex** (OCP **4.20**): `openshift-vertical-pod-autoscaler` pins `vertical-pod-autoscaler.v4.21.0-202604221819`, but that cluster's `redhat-operators` catalog only carries **`v4.20.0-*`** builds (23 entries, head `v4.20.0-202607150525`) — no `v4.21.0-*` exists there at all. Result: VPA operator never installed, `Subscription` stuck `ResolutionFailed`, both hook Jobs failed with *"Job was active longer than specified deadline"*, and `openshift-vertical-pod-autoscaler-instance` stayed `Missing` (its `VerticalPodAutoscalerController` CRD ships with the operator CSV). `CatalogSourcesUnhealthy=False` — the catalog was fine, the pin was simply unsatisfiable.

This is the generic failure mode for any operator whose builds are tied to the cluster's OCP minor: the catalog only carries builds for the running release train, so a hard pin is guaranteed to break across OCP versions — which is precisely what `track` exists to solve.

## Change

Omit `startingCSV` when `pinPolicy: track`, so OLM resolves the channel head and the approver gates the resulting InstallPlan instead. `csv` is retained under track as documentation of intended baseline (and still names the approver/verifier Jobs). Docs in `values.yaml` updated to state this explicitly.

**Backward compatible:** `strict` and the default (unset ⇒ strict) keep emitting `startingCSV`, so every existing pinned operator is unchanged. Bonus: no longer emits `startingCSV: ""` when `csv` is unset.

## Testing

`helm template` across all four cases:

| values | `startingCSV` |
|---|---|
| `pinPolicy: track` | **omitted** ✅ |
| `pinPolicy: strict` | present (unchanged) ✅ |
| no `pinPolicy` (default) | present (unchanged) ✅ |
| `csv` unset | omitted (was `""`) ✅ |

`helm lint` clean; full chart render parses as valid YAML (7 docs).

## Follow-ups (separate PRs, not in this one)

The VPA addon then needs `pinPolicy: track` actually set — catalog `openshift-vertical-pod-autoscaler` chart (bump the `operators-installer` dep off 1.0.7) + the kubestack-config addon values. Tracked under SA-8641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)