### PR TITLE
fix(operators-installer): let failed approver/verifier Jobs be replaced

### DIFF
--- a/operators-installer/templates/installplan-approver/csv-verifier.yaml
+++ b/operators-installer/templates/installplan-approver/csv-verifier.yaml
@@ -11,6 +11,20 @@ metadata:
     {{- include "operators-installer.labels" $ | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+    # Unlike the approver/verifier Jobs this one is a NORMAL synced resource, not an
+    # Argo hook, so hook-delete-policy does not apply to it — it needs the non-hook
+    # equivalent. Its name derives from `csv` and a Job's spec.template is immutable,
+    # so once this Job has FAILED, ArgoCD can only try to patch it and the sync dies
+    # with
+    #   Job.batch "<csv>-csv-verifier" is invalid: spec.template: Invalid value: ...
+    # leaving the app Degraded on a stale failure that no longer reflects reality,
+    # and unable to re-verify after the underlying problem is fixed. Observed on
+    # y0c8muex: a 15h-old failed csv-verifier kept openshift-vertical-pod-autoscaler
+    # Degraded even once the operator was installed and Running, and only a manual
+    # `oc delete job` cleared it (SA-8641).
+    # Force+Replace makes ArgoCD delete and recreate it (kubectl replace --force)
+    # instead of patching, which is the only way to roll an immutable Job.
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   completions: 1
   parallelism: 1

--- a/operators-installer/values.yaml
+++ b/operators-installer/values.yaml
@@ -13,7 +13,17 @@ approveManualInstallPlanViaHook: true
 installPlanApproverAndVerifyJobsImage: quay.io/openshift/origin-cli:4.20.0
 
 annotations:
-  argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  # BeforeHookCreation is load-bearing, not tidiness. These Jobs are named after the
+  # operator's `csv` value, so the name is stable across syncs — and a Job's
+  # spec.template is immutable. A previously FAILED approver/verifier Job therefore
+  # blocks its own replacement: ArgoCD tries to patch it and the sync dies with
+  #   Job.batch "<csv>-approver" is invalid: spec.template: Invalid value: ...
+  # so the InstallPlan is never approved and the operator never installs — even
+  # after the values that caused the original failure have been corrected. Recovery
+  # then needs the stale Jobs deleted by hand (hit twice on y0c8muex while fixing
+  # the VPA pin, SA-8641). HookSucceeded alone does not help: it only removes Jobs
+  # that succeeded, and it is exactly the failed ones that wedge the next sync.
+  argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
   argocd.argoproj.io/hook: Sync
 
 ## Both Helm are argo hooks are defined . as per docs . If you define some Argo CD hooks in addition to the Helm ones, the Helm hooks will be ignored.


### PR DESCRIPTION
## A failed Job blocks its own replacement

All three Jobs are named from the operator's `csv` value, so the name is **stable across syncs** — and a Job's `spec.template` is **immutable**. Once one has FAILED, ArgoCD can only try to patch it, and the sync dies:

```
Job.batch "<csv>-approver" is invalid: spec.template: Invalid value: ...
```

The InstallPlan is then never approved and the operator never installs — **with the corrected values sitting right there in the Subscription, doing nothing**. A cluster cannot recover from a bad pin even after the pin is fixed.

## Hit twice on y0c8muex while fixing the VPA pin (SA-8641)

Both times recovery required `oc delete job` by hand:

1. stale `<csv>-approver` / `<csv>-verifier` blocked the sync outright → InstallPlan stayed `approved=false`
2. a **15h-old failed `<csv>-csv-verifier`** kept `openshift-vertical-pod-autoscaler` **Degraded even after the operator was installed and Running**

## Two mechanisms, because the Jobs aren't the same kind of resource

This is the part that isn't obvious:

| Job | what it is | fix |
|---|---|---|
| `approver`, `verifier` | Argo **hooks** | add **`BeforeHookCreation`** to `hook-delete-policy` |
| `csv-verifier` | **not a hook** — plain synced resource at `sync-wave: 20`, so its health gates the app | `hook-delete-policy` doesn't apply at all → needs **`Force=true,Replace=true`** |

`HookSucceeded` alone is no help: it only removes Jobs that **succeeded**, and it's precisely the **failed** ones that wedge the next sync. And `Force=true,Replace=true` makes ArgoCD delete+recreate (`kubectl replace --force`) instead of patching, which is the only way to roll an immutable Job.

## Verification

`helm template` confirms:

```
<csv>-approver      hook=Sync  delete-policy=HookSucceeded,BeforeHookCreation
<csv>-verifier      hook=Sync  delete-policy=HookSucceeded,BeforeHookCreation
<csv>-csv-verifier  (not a hook)  sync-options=Force=true,Replace=true
```

`helm lint` clean; full render still parses (7 docs).

## Note on behaviour change

`csv-verifier` will now be recreated on each sync rather than patched, so it re-runs — acceptable for a verifier, and it's what allows a stale failure to clear itself instead of pinning the app Degraded forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)