### PR TITLE
feat(crossplane-observability): ship the optional core metrics Service

### DIFF
--- a/crossplane-observability/Chart.yaml
+++ b/crossplane-observability/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crossplane-observability
 description: A Helm chart for Crossplane observability (ServiceMonitor + PrometheusRule + Grafana dashboard), integrated with OpenShift user-workload monitoring.
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "0.0.1"

--- a/crossplane-observability/README.md
+++ b/crossplane-observability/README.md
@@ -52,6 +52,11 @@ UWM evaluates these `PrometheusRule`s in `thanos-ruler-user-workload`.
 ### 2. Crossplane metrics exposed
 
 - **Core:** start core with `--set metrics.enabled=true` (Helm) so `/metrics` is served.
+  Upstream ships **no Service** in front of that port, so a `ServiceMonitor` has nothing to
+  select. Either point `crossplane.core.serviceMonitorSelector` at a metrics Service your
+  cluster already has, or let this chart create one with
+  `prometheus.monitors.coreMetricsService.enabled=true` (set its `selector` to your core pod
+  labels — the upstream chart labels them `app: crossplane`, `release: <release name>`).
 - **Providers:** expose a metrics port on each provider via its `DeploymentRuntimeConfig`.
   Every crossplane-runtime provider emits `crossplane_managed_resource_*` natively
   (ready/synced/TTR/drift) — no external exporter is needed for leaf-MR health.
@@ -61,6 +66,7 @@ Then turn on the scrapers (both default to `false`):
 ```yaml
 prometheus:
   monitors:
+    coreMetricsService: { enabled: true }   # only if the cluster has no metrics Service
     coreServiceMonitor: { enabled: true }
     providerPodMonitor: { enabled: true }
 ```
@@ -223,6 +229,8 @@ These need cluster/Grafana context an agent can't safely guess:
 | `grafana.compositeAlerts.enabled` | `false` | Story 4.1 composite alerts as **Grafana-managed** rules (use on UWM instead of the PrometheusRule composite alerts). |
 | `grafana.compositeAlerts.datasourceUid` | `""` | **Required when enabled** — UID of the cross-namespace Prometheus/Thanos datasource in Grafana. |
 | `grafana.namespace` | release ns | Namespace to create the GrafanaDashboard in. |
+| `prometheus.monitors.coreMetricsService.enabled` | `false` | Create the headless metrics Service for Crossplane core (upstream ships none, so `coreServiceMonitor` has nothing to select without it). Its name defaults to `crossplane.core.job` — which is what makes the `job` label match — and its labels to `crossplane.core.serviceMonitorSelector.matchLabels`. |
+| `prometheus.monitors.coreMetricsService.selector` | `{app: crossplane, release: crossplane}` | Pod labels of the Crossplane core Deployment. **Install-specific** — the upstream chart sets `release: <helm release name>`. |
 | `prometheus.monitors.coreServiceMonitor.enabled` | `false` | Scrape Crossplane core. |
 | `prometheus.monitors.providerPodMonitor.enabled` | `false` | Scrape provider pods. |
 | `prometheus.recordingRules.enabled` | `true` | Emit the SLO recording rules. |

--- a/crossplane-observability/docs/values-stakater-cloud-example.yaml
+++ b/crossplane-observability/docs/values-stakater-cloud-example.yaml
@@ -6,12 +6,33 @@
 
 # The cluster already scrapes core + providers via its own ServiceMonitor/PodMonitor, so the
 # chart's monitors stay OFF; the rules just point at the existing Prometheus jobs.
+#
+# ⚠️ CONFIRM this per cluster — it is NOT true of every Stakater Cloud cluster. Those
+# monitors and the `crossplane-metrics` Service they select are hand-applied platform
+# objects, not part of any chart, so a cluster can be missing them entirely and every rule
+# and panel then evaluates against nothing. Check with:
+#   kubectl get servicemonitor,podmonitor -A | grep -i crossplane
+#   kubectl get svc -n crossplane-system | grep metrics
+# If they are absent, turn the chart's own scrape on instead (see the commented block
+# below) rather than hand-applying more unowned objects.
 prometheus:
   monitors:
     coreServiceMonitor:
       enabled: false
     providerPodMonitor:
       enabled: false
+    # If the cluster has NO crossplane-metrics Service, uncomment these three blocks. The
+    # Service is named after `crossplane.core.job` below, so the core rules keep matching;
+    # set `selector` to your core pods' labels (the upstream chart uses
+    # `release: <helm release name>` — `crossplane-operator` on us-2, `crossplane` on eu-2)
+    # and override `crossplane.providers.job` to
+    # `crossplane-system/<release>-crossplane-observability-providers`, because a PodMonitor's
+    # job label is `<namespace>/<podmonitor-name>` and will not match the value set below.
+    # coreMetricsService:
+    #   enabled: true
+    #   selector:
+    #     app: crossplane
+    #     release: crossplane
   rules:
     fleet:
       # On UWM, keep the PrometheusRule composite alerts OFF — Grafana handles them

--- a/crossplane-observability/templates/prometheus/monitors/core-metrics-service.yaml
+++ b/crossplane-observability/templates/prometheus/monitors/core-metrics-service.yaml
@@ -1,0 +1,37 @@
+{{- if and ( .Values.prometheus.monitors.coreMetricsService ) ( .Values.prometheus.monitors.coreMetricsService.enabled ) }}
+{{- $svc := .Values.prometheus.monitors.coreMetricsService }}
+{{- $sm := .Values.prometheus.monitors.coreServiceMonitor | default dict }}
+{{- $sel := .Values.crossplane.core.serviceMonitorSelector | default dict }}
+# Headless Service in front of the Crossplane core pods' /metrics port.
+#
+# Crossplane core serves /metrics (with `metrics.enabled=true`) but upstream ships NO Service
+# for it, so `coreServiceMonitor` selects nothing unless the cluster happens to have one
+# hand-applied. Enable this and the chart owns both halves of the scrape.
+#
+# Two couplings are derived rather than restated, so the pair cannot drift apart:
+#   * the Service NAME becomes the `job` label on every core metric (prometheus-operator
+#     derives a ServiceMonitor's job from the Service), so it defaults to
+#     `crossplane.core.job` — the value the alert and recording expressions filter on;
+#   * its LABELS are the ServiceMonitor's own selector `matchLabels`, so the monitor this
+#     chart ships always matches the Service this chart ships. (Only `matchLabels` is
+#     reflected — a selector written with `matchExpressions` must be matched by hand.)
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $svc.name | default .Values.crossplane.core.job }}
+  namespace: {{ include "crossplane-observability.namespace" . }}
+  labels:
+    {{- /* the monitor's selector labels win over the chart defaults — see the note above */}}
+    {{- merge (deepCopy ($sel.matchLabels | default dict)) (fromYaml (include "crossplane-observability.labels" .)) | toYaml | nindent 4 }}
+spec:
+  # Headless: this Service exists only to produce Endpoints for the scrape. Nothing dials
+  # it by name, so it needs no ClusterIP.
+  clusterIP: None
+  selector:
+    {{- toYaml $svc.selector | nindent 4 }}
+  ports:
+    - name: {{ $sm.port | default "metrics" }}
+      port: {{ $svc.port }}
+      targetPort: {{ $svc.targetPort }}
+      protocol: TCP
+{{- end }}

--- a/crossplane-observability/tests/validate.sh
+++ b/crossplane-observability/tests/validate.sh
@@ -24,6 +24,7 @@ green() { printf "\033[32m%s\033[0m\n" "$*"; }
 step()  { printf "\n\033[1m== %s ==\033[0m\n" "$*"; }
 
 ALL_FLAGS=(
+  --set prometheus.monitors.coreMetricsService.enabled=true
   --set prometheus.monitors.coreServiceMonitor.enabled=true
   --set prometheus.monitors.providerPodMonitor.enabled=true
   --set upjet.enabled=true

--- a/crossplane-observability/values.yaml
+++ b/crossplane-observability/values.yaml
@@ -33,6 +33,8 @@ crossplane:
     # Label selector for the core metrics Service (used only when coreServiceMonitor is
     # enabled). Default targets the metrics Service by component; the upstream metrics
     # Service has no per-instance label, so don't require one.
+    # `prometheus.monitors.coreMetricsService` labels the Service it creates with exactly
+    # these matchLabels, so leaving both at their defaults always pairs.
     serviceMonitorSelector:
       matchLabels:
         app.kubernetes.io/name: crossplane
@@ -148,11 +150,35 @@ grafana:
 # Prometheus configuration
 # ---------------------------------------------------------------------------
 prometheus:
-  # Scrape configuration. Both default to disabled — turn them on once the matching
+  # Scrape configuration. All default to disabled — turn them on once the matching
   # metrics ports are confirmed exposed (see docs/roadmap.md, Decision 2).
   monitors:
+    # Headless Service in front of the core pods' /metrics port. Upstream Crossplane
+    # serves /metrics but ships NO Service for it, so `coreServiceMonitor` below selects
+    # nothing unless the cluster has one hand-applied. Enable this to have the chart own
+    # both halves of the core scrape.
+    coreMetricsService:
+      enabled: false
+      # Service name. Prometheus-operator derives a ServiceMonitor's `job` label from the
+      # Service, so this name IS the job label — it defaults to `crossplane.core.job` so
+      # the alert/recording expressions match without a second setting to keep in sync.
+      # Override only if your Prometheus relabels the job.
+      name: ""
+      # Pod labels of the Crossplane core Deployment. Varies by install: the upstream
+      # chart sets `release: <helm release name>`, so this default fits a release named
+      # `crossplane`. Check with
+      #   kubectl get pod -n <ns> -l app=crossplane --show-labels
+      selector:
+        app: crossplane
+        release: crossplane
+      # Port the core pods serve /metrics on. Crossplane's Deployment does not declare it
+      # as a containerPort, which is fine — a Service may target a raw port number. The
+      # port NAME is taken from `coreServiceMonitor.port` so the two always agree.
+      port: 8080
+      targetPort: 8080
     # Scrapes Crossplane core /metrics (controller-runtime, workqueue, circuit
-    # breaker, function-pipeline metrics).
+    # breaker, function-pipeline metrics). Needs a metrics Service to select — either
+    # `coreMetricsService` above, or one already present on the cluster.
     coreServiceMonitor:
       enabled: false
       port: metrics


### PR DESCRIPTION
## What

Adds `prometheus.monitors.coreMetricsService` (default **off**) — a headless Service in front of the Crossplane core pods' `/metrics` port.

## Why

The chart has offered `coreServiceMonitor` since #274, but never shipped anything for it to select. Crossplane core serves `/metrics` when started with `metrics.enabled=true`, and **upstream ships no Service in front of that port**. So `coreServiceMonitor.enabled=true` on its own matches nothing, and every core alert and panel evaluates against no data — with no error anywhere.

Found live on **eu-2** while verifying the addon rollout:

- the addon deployed clean — 14 objects, dashboard `DashboardSynchronized=True`, thanos-ruler showing 16 crossplane groups and 21 rules all `health: ok`
- …and **0 alert instances, every recording rule empty** (us-2: 60 instances, 53 series)
- root cause: no `crossplane-metrics` Service, no ServiceMonitor/PodMonitor mentioning crossplane anywhere on the cluster, no inventory exporter

Probing the eu-2 core pod IP directly returned **HTTP 200, 1.84 MB** — the metrics were there the whole time with nothing scraping them. **us-2 works only by accident of history:** its `Service crossplane-metrics`, `ServiceMonitor crossplane-core` and `PodMonitor crossplane-providers-and-functions` are 77-day-old `kubectl apply`ed objects with no ownerRefs, no Helm labels and no Argo tracking — owned by nobody, and never replicated to eu-2.

## The design: derive the couplings, don't restate them

This wiring has two places it can silently mismatch, and both have already bitten this chart. Neither is a second setting to keep in sync:

| Coupling | How it's handled |
| --- | --- |
| Service **name** → the `job` label (prometheus-operator derives a ServiceMonitor's job from the Service) | defaults to `crossplane.core.job` — the exact label the alert/recording expressions filter on |
| Service **labels** → the monitor's selector | defaults to `crossplane.core.serviceMonitorSelector.matchLabels`, so the monitor this chart ships always matches the Service it ships |

`selector` is the one genuinely install-specific value and must be set per cluster: the upstream chart labels core pods `release: <helm release name>` — `crossplane` on eu-2, `crossplane-operator` on us-2. It is documented as such in `values.yaml` and the README, with the discovery command.

## Verification

- **Rendered object is label-, port- and headless-identical to us-2's working hand-applied Service** (`{app.kubernetes.io/name: crossplane, app.kubernetes.io/component: metrics}`, `clusterIP: None`, port `metrics` 8080→8080) — i.e. this ships the configuration already proven to produce data, rather than a new guess.
- `kubectl apply --dry-run=server` on **eu-2**: `service/crossplane-metrics created (server dry run)`; the default selector matches the live core pod (`crossplane-7db758bdbd-w8p25`).
- With eu-2's real `crossplane.core.job=crossplane-metrics`, the Service renders as `crossplane-metrics` — so **eu-2's 4 core rules start matching with no values override**.
- `./tests/validate.sh` **green**: helm lint, both renders, 29 rules parse, promtool rule logic, metric gate 18/28 captured, 39 panel queries parse, kubeconform strict **25/25 valid** (up from 24 — the new Service, validated against the built-in schema; the suite's `ALL_FLAGS` now enables it so it can't regress unchecked).
- Crossplane's Deployment does not declare 8080 as a `containerPort`. That is fine — a Service may target a raw port number, and it is exactly what us-2 does today. An undeclared containerPort is **not** evidence metrics are off.

## Docs

`docs/values-stakater-cloud-example.yaml` said the cluster already scrapes core + providers, with the chart's monitors off. eu-2 proves that is a **per-cluster assumption, not a Stakater Cloud guarantee**, so it now carries the check commands and a ready-to-uncomment block. Also records the PodMonitor job-label trap: a PodMonitor's job is `<namespace>/<podmonitor-name>`, so enabling the chart's provider scrape renders `crossplane-system/<release>-crossplane-observability-providers` and does **not** match the example's `crossplane.providers.job` — that one needs overriding too.

## Not in scope

- eu-2 still has no inventory exporter (`ksm-crossplane`), so the inventory / composite / billing rows stay empty there regardless — separate, and already documented via `docs/resource-state-metrics-example.yaml`.
- Actually turning this on for eu-2 is a GitOps EnvironmentConfig change in `stakater-cloud-gitops-nonprod`, not a chart change. This PR only makes it possible.

Default is `false`, so no existing install changes behaviour.

Refs SA-8539, #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
