### PR TITLE
fix(crossplane-observability): make the core metrics Service selector install-agnostic

### DIFF
--- a/crossplane-observability/Chart.yaml
+++ b/crossplane-observability/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crossplane-observability
 description: A Helm chart for Crossplane observability (ServiceMonitor + PrometheusRule + Grafana dashboard), integrated with OpenShift user-workload monitoring.
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "0.0.1"

--- a/crossplane-observability/README.md
+++ b/crossplane-observability/README.md
@@ -55,8 +55,9 @@ UWM evaluates these `PrometheusRule`s in `thanos-ruler-user-workload`.
   Upstream ships **no Service** in front of that port, so a `ServiceMonitor` has nothing to
   select. Either point `crossplane.core.serviceMonitorSelector` at a metrics Service your
   cluster already has, or let this chart create one with
-  `prometheus.monitors.coreMetricsService.enabled=true` (set its `selector` to your core pod
-  labels — the upstream chart labels them `app: crossplane`, `release: <release name>`).
+  `prometheus.monitors.coreMetricsService.enabled=true`. Its default selector `{app: crossplane}`
+  is install-agnostic — that label comes from the upstream chart's name, not the release name —
+  so it needs no per-cluster value unless Crossplane was installed with a `nameOverride`.
 - **Providers:** expose a metrics port on each provider via its `DeploymentRuntimeConfig`.
   Every crossplane-runtime provider emits `crossplane_managed_resource_*` natively
   (ready/synced/TTR/drift) — no external exporter is needed for leaf-MR health.
@@ -230,7 +231,7 @@ These need cluster/Grafana context an agent can't safely guess:
 | `grafana.compositeAlerts.datasourceUid` | `""` | **Required when enabled** — UID of the cross-namespace Prometheus/Thanos datasource in Grafana. |
 | `grafana.namespace` | release ns | Namespace to create the GrafanaDashboard in. |
 | `prometheus.monitors.coreMetricsService.enabled` | `false` | Create the headless metrics Service for Crossplane core (upstream ships none, so `coreServiceMonitor` has nothing to select without it). Its name defaults to `crossplane.core.job` — which is what makes the `job` label match — and its labels to `crossplane.core.serviceMonitorSelector.matchLabels`. |
-| `prometheus.monitors.coreMetricsService.selector` | `{app: crossplane, release: crossplane}` | Pod labels of the Crossplane core Deployment. **Install-specific** — the upstream chart sets `release: <helm release name>`. |
+| `prometheus.monitors.coreMetricsService.selector` | `{app: crossplane}` | Pod labels of the Crossplane core Deployment. Install-agnostic: `app` derives from the upstream chart's name (not the release name) and is unique to core — rbac-manager is `app: crossplane-rbac-manager`, and provider/function pods carry no `app` label. Don't swap in the `app.kubernetes.io/*` labels: core and rbac-manager carry identical values there, and rbac-manager also serves /metrics on 8080. |
 | `prometheus.monitors.coreServiceMonitor.enabled` | `false` | Scrape Crossplane core. |
 | `prometheus.monitors.providerPodMonitor.enabled` | `false` | Scrape provider pods. |
 | `prometheus.recordingRules.enabled` | `true` | Emit the SLO recording rules. |

--- a/crossplane-observability/docs/values-stakater-cloud-example.yaml
+++ b/crossplane-observability/docs/values-stakater-cloud-example.yaml
@@ -22,17 +22,14 @@ prometheus:
     providerPodMonitor:
       enabled: false
     # If the cluster has NO crossplane-metrics Service, uncomment these three blocks. The
-    # Service is named after `crossplane.core.job` below, so the core rules keep matching;
-    # set `selector` to your core pods' labels (the upstream chart uses
-    # `release: <helm release name>` — `crossplane-operator` on us-2, `crossplane` on eu-2)
-    # and override `crossplane.providers.job` to
+    # Service is named after `crossplane.core.job` below, so the core rules keep matching,
+    # and its default selector `{app: crossplane}` needs no per-cluster value — that label
+    # tracks the upstream chart's name, not the release name (which is `crossplane-operator`
+    # on us-2 and `crossplane` on eu-2). But DO override `crossplane.providers.job` to
     # `crossplane-system/<release>-crossplane-observability-providers`, because a PodMonitor's
     # job label is `<namespace>/<podmonitor-name>` and will not match the value set below.
     # coreMetricsService:
     #   enabled: true
-    #   selector:
-    #     app: crossplane
-    #     release: crossplane
   rules:
     fleet:
       # On UWM, keep the PrometheusRule composite alerts OFF — Grafana handles them

--- a/crossplane-observability/values.yaml
+++ b/crossplane-observability/values.yaml
@@ -164,13 +164,22 @@ prometheus:
       # the alert/recording expressions match without a second setting to keep in sync.
       # Override only if your Prometheus relabels the job.
       name: ""
-      # Pod labels of the Crossplane core Deployment. Varies by install: the upstream
-      # chart sets `release: <helm release name>`, so this default fits a release named
-      # `crossplane`. Check with
+      # Pod labels of the Crossplane core Deployment. `app` is the one label that is both
+      # install-agnostic and unique to core, so this default needs no per-cluster value:
+      #   * it comes from the upstream chart's `nameOverride | default .Chart.Name`, not
+      #     from the release name — so it is `crossplane` whether the release is called
+      #     `crossplane` (eu-2) or `crossplane-operator` (us-2), whereas `release:` is the
+      #     part that differs and is deliberately NOT selected on;
+      #   * the rbac-manager pod is `app: crossplane-rbac-manager`, so equality matching
+      #     excludes it. Do NOT select on the `app.kubernetes.io/*` labels instead: core
+      #     and rbac-manager carry byte-identical `name`/`part-of`/`component` values, and
+      #     rbac-manager also serves /metrics on 8080 — it would be scraped as core;
+      #   * provider and function pods carry only `pkg.crossplane.io/{revision,provider,
+      #     function}` (Crossplane builds those Deployments itself), so no `app` key at all.
+      # Override only if the Crossplane chart was installed with a `nameOverride`. Check:
       #   kubectl get pod -n <ns> -l app=crossplane --show-labels
       selector:
         app: crossplane
-        release: crossplane
       # Port the core pods serve /metrics on. Crossplane's Deployment does not declare it
       # as a containerPort, which is fine — a Service may target a raw port number. The
       # port NAME is taken from `coreServiceMonitor.port` so the two always agree.


### PR DESCRIPTION
## What

Drops `release` from `prometheus.monitors.coreMetricsService.selector`, leaving `{app: crossplane}`.

## Why

#288 gave the chart a metrics Service so `coreServiceMonitor` finally has something to select. But its selector defaulted to `{app: crossplane, release: crossplane}`, and `release` is the **helm release name** — `crossplane` on eu-2, `crossplane-operator` on us-2. So the one value standing between a fresh install and a working core scrape had to be set per cluster, and getting it wrong **fails silently**: the Service is created, selects no pods, produces no Endpoints, and every core rule and panel evaluates against no data — indistinguishable from not installing the Service at all. That is the same silent-empty failure mode #288 set out to remove.

`app` is the one label that is both install-agnostic and unique to core.

## How this was established

From the upstream chart source, not from one cluster's pods — rendering `crossplane` 2.3.4 under an arbitrary release name:

| Pod | `app` | `release` | `app.kubernetes.io/{name,part-of,component}` |
|---|---|---|---|
| core | `crossplane` | `co` | `crossplane` / `crossplane` / `cloud-infrastructure-controller` |
| rbac-manager | `crossplane-rbac-manager` | `co` | **identical to core** |
| provider / function | — | — | — |

- `app` is `crossplane.name` = `nameOverride \| default .Chart.Name`, so it does not move with the release name.
- rbac-manager is `app: crossplane-rbac-manager`, so equality matching excludes it.
- **`app.kubernetes.io/*` would have been the wrong fix** despite looking like the standard answer: `crossplane.labels` is included verbatim by both Deployments, so those keys are byte-identical between core and rbac-manager — and rbac-manager also carries `prometheus.io/port: "8080"` and serves /metrics. A selector built from them would have quietly scraped rbac-manager **as core** and doubled the series.
- provider/function pods carry only `pkg.crossplane.io/{revision,provider,function}`. Crossplane's package runtime builds those Deployments itself (`DeploymentRuntimeBuilder.podSelectors`, `maps.Copy`'d into the pod template) and sets no `app` key, so they cannot be swept in either.

The remaining override case is narrow and now documented: an upstream install using `nameOverride`.

## Verification

- `helm template` with `coreMetricsService.enabled=true` renders `selector: {app: crossplane}`, headless, port `metrics` 8080→8080 — unchanged apart from the dropped key.
- `./tests/validate.sh` green: 25 objects strict-validated against CRD schemas, 29 rules, 39 panel queries parse, metric gate 18/28 captured.
- Not re-verified live this session — both cluster tokens are expired. The label facts above come from the chart source, which is stronger than a single cluster's pods anyway; the previous live check on eu-2 (#288) confirmed `{app: crossplane, release: crossplane}` matched the core pod there.

## Why it matters beyond tidiness

eu-2's dashboard is empty today for exactly this reason chain, and the addon is supposed to work end-to-end from a ksp upgrade with no per-cluster values. This is the chart-side prerequisite for turning the scrape on in the saap-catalog wrapper baseline (next PR); with `release` in the default, that flip would have created a Service matching nothing on any cluster whose release is not named `crossplane`.

Refs SA-8539, #283, follows #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
