### PR TITLE
fix(crossplane-observability): label provider metrics with their provider

### DIFF
--- a/crossplane-observability/Chart.yaml
+++ b/crossplane-observability/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crossplane-observability
 description: A Helm chart for Crossplane observability (ServiceMonitor + PrometheusRule + Grafana dashboard), integrated with OpenShift user-workload monitoring.
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "0.0.1"

--- a/crossplane-observability/templates/prometheus/monitors/provider-podmonitor.yaml
+++ b/crossplane-observability/templates/prometheus/monitors/provider-podmonitor.yaml
@@ -22,4 +22,29 @@ spec:
       path: {{ $pm.path }}
       interval: {{ $pm.interval }}
       scrapeTimeout: {{ $pm.scrapeTimeout }}
+      # Promote the package-runtime pod labels to series labels. Without these, every
+      # provider's metrics are distinguishable only by `pod`/`instance` — churning
+      # values that change on every revision roll — so "which provider is failing?"
+      # cannot be asked of the data at all.
+      #
+      # These are not install-specific: Crossplane's package runtime stamps
+      # pkg.crossplane.io/{provider,function,revision} onto every Deployment it builds,
+      # so the same three labels exist on every cluster. They are hardcoded rather than
+      # exposed as a value deliberately — a relabeling knob invites restating a coupling
+      # the chart can derive, which is how the job-label bugs happened.
+      #
+      # `crossplane_provider` in particular is the grouping label operators already
+      # query on (a hand-written provider scrape on Stakater Cloud emits exactly these),
+      # so shipping them lets this PodMonitor replace such a scrape without silently
+      # emptying whatever was built on it.
+      relabelings:
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_label_pkg_crossplane_io_provider]
+          targetLabel: crossplane_provider
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_label_pkg_crossplane_io_function]
+          targetLabel: crossplane_function
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_label_pkg_crossplane_io_revision]
+          targetLabel: crossplane_revision
 {{- end }}


### PR DESCRIPTION
## What

The provider `PodMonitor` now promotes the package-runtime pod labels to series labels:

| pod label | series label |
|---|---|
| `pkg.crossplane.io/provider` | `crossplane_provider` |
| `pkg.crossplane.io/function` | `crossplane_function` |
| `pkg.crossplane.io/revision` | `crossplane_revision` |

## Why

The PodMonitor scraped the provider pods but promoted none of their identity, so every
provider's series were distinguishable only by `pod` and `instance` — values that change on
every revision roll. *"Which provider is failing?"* was not a question the scraped data could
answer.

The labels come from Crossplane itself: the package runtime stamps
`pkg.crossplane.io/{provider,function,revision}` onto every Deployment it builds, so they are
present on every install.

## Why this matters right now

This is the last gap between the chart's own scrape and the hand-written one it is meant to
replace. On Stakater Cloud's us-2 an unowned `PodMonitor` emits exactly these three labels, and
a `PrometheusRule` there (`crossplane-health`) groups on `crossplane_provider`:

```promql
sum by (crossplane_provider, gvk) (crossplane_managed_resource_ready{status="False"}) > 0
```

Verified live on us-2 — the series carry `crossplane_provider` / `crossplane_revision` today.
Without this change, deleting that unowned monitor in favour of the chart's would leave those
alerts rendering, parsing, evaluating — and matching nothing. That is the same silent-empty
failure class as #288/#289/#290; this closes the last instance of it in the scrape path.

## Design note

Hardcoded rather than exposed as a values knob, deliberately. The labels are a property of
Crossplane, not of the install, and a relabeling knob invites restating a coupling the chart can
already derive — which is precisely the shape of the job-label bugs fixed in #289 and #290.

## What is NOT affected

No rule, recording rule or dashboard panel in this chart references the three labels, so no
shipped expression changes. This is purely additive to the emitted series.

## Verification

`tests/validate.sh` — all 6 steps pass:

- **1c scrape/job coherence** — job labels still coherent (Service + PodMonitor both queried by rules)
- **2** promtool check — 29 rules
- **3** promtool test (logic) — SUCCESS
- **4** metric gate — 18/28 captured, 10 documented, 7 recording refs resolved
- **5/5b** dashboard JSON valid, 39 panel queries parse
- **6** kubeconform strict — 25/25 valid (covers the new `relabelings` block against the PodMonitor CRD schema)

Live label shape confirmed against us-2 via thanos-querier before writing the relabelings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
